### PR TITLE
Run tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+jobs:
+  Test:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Yarn Cache
+          keys:
+            - yarn-{{ checksum "yarn.lock" }}
+      - run:
+          name: Yarn Install
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Cache
+          key: yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          name: Run Checks
+          command: yarn jest --ci --runInBand --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT: "reports/test-results/test-results.xml"
+      - store_test_results:
+          path: ./reports/test-results
+
+workflows:
+  peril-settings:
+    jobs:
+      - Test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "license": "GPLv2",
+  "license": "GPL-2.0-or-later",
   "scripts": {
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/jest": "^24.0.14",
     "danger": "^8.0.0",
     "jest": "^24.8.0",
+    "jest-junit": "^6.4.0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,16 @@ jest-jasmine2@^24.8.0:
     pretty-format "^24.8.0"
     throat "^4.0.0"
 
+jest-junit@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-6.4.0.tgz#23e15c979fa6338afde46f2d2ac2a6b7e8cf0d9e"
+  integrity sha512-GXEZA5WBeUich94BARoEUccJumhCgCerg7mXDFLxWwI2P7wL3Z7sGWk+53x343YdBLjiMR9aD/gYMVKO+0pE4Q==
+  dependencies:
+    jest-validate "^24.0.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz#c0086384e1f650c2d8348095df769f29b48e6980"
@@ -2013,7 +2023,7 @@ jest-util@^24.8.0:
     slash "^2.0.0"
     source-map "^0.6.0"
 
-jest-validate@^24.8.0:
+jest-validate@^24.0.0, jest-validate@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.8.0.tgz#624c41533e6dfe356ffadc6e2423a35c2d3b4849"
   dependencies:
@@ -3766,6 +3776,11 @@ ws@^5.2.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This PR adds a CircleCI config to run our newly added jest tests on CircleCI (https://github.com/Automattic/peril-settings/pull/7).

It also updates `package.json` with a new dependency to support this and updates the licence to remove a warning.

### To Test

See that CircleCI has successfully run the tests on this PR.

cc @markpar 