### PR TITLE
Update libs/login check and add to WooCommerce-Android

### DIFF
--- a/org/github/check-login-subtree.ts
+++ b/org/github/check-login-subtree.ts
@@ -1,4 +1,4 @@
-import {warn, danger} from "danger";
+import {message, danger} from "danger";
 
 /*
     This rule scans a PR for changes in a specific subtree and adds
@@ -41,6 +41,6 @@ export default async () => {
         markdownText += `3. \`git subtree push --prefix=${subtreePath} https://github.com/${org}/${destRepo}.git ${mergeBranch}\`\n`;
         markdownText += `4. Browse to https://github.com/${org}/${destRepo}/pull/new/${mergeBranch} and open a new PR.`;
         
-        warn(markdownText);
+        message(markdownText);
     }
 };

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -39,7 +39,8 @@
                 "Automattic/peril-settings@org/android.ts",
                 "Automattic/peril-settings@org/github/label.ts",
                 "Automattic/peril-settings@org/github/milestone.ts",
-                "Automattic/peril-settings@org/github/diff-size.ts"
+                "Automattic/peril-settings@org/github/diff-size.ts",
+                "Automattic/peril-settings@org/github/check-login-subtree.ts"
             ]
         },
         "Automattic/simplenote-ios": {

--- a/tests/check-login-subtree.test.ts
+++ b/tests/check-login-subtree.test.ts
@@ -6,7 +6,7 @@ import checkLoginSubtree from "../org/github/check-login-subtree";
 
 // The mocked data and return values for calls the rule makes.
 beforeEach(() => {
-    dm.warn = jest.fn().mockReturnValue(true);
+    dm.message = jest.fn().mockReturnValue(true);
 
     dm.danger = {
         git: {
@@ -31,9 +31,9 @@ describe("/libs/login subtree check", () => {
         await checkLoginSubtree();
         
         // First, check that the merge instructions appear correct.
-        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/login/`"));
+        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/login/`"));
         
         // Then, ensure a piece of mock data is present.
-        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
+        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
     })
 })


### PR DESCRIPTION
This is a quick follow up to the work @markpar did in https://github.com/Automattic/peril-settings/pull/7.

I've made these two changes:

- Post the `libs/login` instructions as a message instead of a warning. This isn't always an error case (e.g. release branches) so I think that is more suitable.
- Add the check to WCAndroid now that it has been working reliably 😄 