### PR TITLE
CircleCI: Restart Heroku on push to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  heroku: circleci/heroku@0.0.8
+
 jobs:
   Test:
     docker:
@@ -25,8 +28,25 @@ jobs:
             JEST_JUNIT_OUTPUT: "reports/test-results/test-results.xml"
       - store_test_results:
           path: ./reports/test-results
+  Restart:
+    executor: heroku/default
+    steps:
+      - heroku/install
+      - run:
+          name: Restart automattic-peril
+          command: heroku restart -a automattic-peril
+      - run:
+          name: Restart wordpress-mobile-peril
+          command: heroku restart -a wordpress-mobile-peril
+      - run:
+          name: Restart woocommerce-peril
+          command: heroku restart -a woocommerce-peril
 
 workflows:
   peril-settings:
     jobs:
       - Test
+      - Restart:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This adds a small `Restart` job to CircleCI that runs on `master` to restart the Heroku apps for each org. It means we are always using the latest settings. This wouldn't be needed if the peril settings weren't shared between orgs (see https://github.com/danger/peril/issues/440#issuecomment-510932197).