### PR TITLE
Post comment with APK link on Android PRs with installable builds

### DIFF
--- a/org/pr/android-installable-build.ts
+++ b/org/pr/android-installable-build.ts
@@ -1,0 +1,100 @@
+import { danger } from "danger"
+import { Status } from "github-webhook-event-types"
+import fetch from "node-fetch"
+import * as url from "url";
+import * as path from "path";
+
+const CIRCLECI_TOKEN: string = process.env['CIRCLECI_TOKEN']
+const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
+
+async function circleCIArtifacts(owner: string, repo: string, buildNumber: number) {
+    const url = `https://circleci.com/api/v1.1/project/gh/${owner}/${repo}/${buildNumber}/artifacts?circle-token=${CIRCLECI_TOKEN}`
+    const res = await fetch(url)
+    if (res.ok) {
+      return res.json()
+    }
+    return []
+}
+
+export default async (status: Status) => {
+    if (status.state !== "success") {
+      return console.log(
+        `Not a successful state - got ${status.state}`
+      )
+    }
+
+    if (status.context !== "ci/circleci: Installable Build") {
+        return console.log(
+          `Not an installable build status check - got ${status.context}`
+        )
+    }
+
+    if (!status.target_url) {
+        return console.log(
+          'No target_url on the successful status'
+        )
+    }
+
+    const owner = status.repository.owner.login
+    const repo = status.repository.name
+
+    // CircleCI URLs look like https://circleci.com/gh/:org/:repo/12345?some=query'
+    // We need to extract the build number
+    const urlPath = url.parse(status.target_url).pathname // Gives the /gh/:org/:repo/12345 portion
+    const circleCIBuildNumber = +path.parse(urlPath).base
+
+    const artifacts = await circleCIArtifacts(owner, repo, circleCIBuildNumber)
+    const apkArtifact = artifacts.find(artifact => artifact.path.endsWith(".apk"));
+    if (apkArtifact === undefined) {
+      return console.log(
+        'No APK artifact found on the build'
+      )
+    }
+
+    console.log(`Posting comment for ${apkArtifact.path} at ${apkArtifact.url}`)
+
+    const api = danger.github.api
+
+    // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
+    const repoString = status.repository.full_name
+    const searchResponse = await api.search.issuesAndPullRequests({ q: `${status.commit.sha} type:pr is:open repo:${repoString}` })
+
+    // https://developer.github.com/v3/search/#search-issues
+    const prsWithCommit = searchResponse.data.items.map((i: any) => i.number) as number[]
+    if (prsWithCommit.length === 0) {
+      return console.log(
+        `No open PR found for this commit ${status.commit.sha}`
+      )
+    }
+
+    for (const number of prsWithCommit) {
+      const pull = await api.pulls.get({ owner, repo, number })
+      if (pull.data.head.sha !== status.commit.sha) {
+        console.log(`${status.commit.sha} is not the latest commit on PR ${number}, skipping comment`)
+        continue
+      }
+
+      const commentBody = `You can test the changes on this Pull Request by downloading the APK [here](${apkArtifact.url}).`
+      const allComments = await api.issues.listComments({owner, repo, number})
+
+      const apkComment = allComments.data.find(comment => comment.user.id === PERIL_BOT_USER_ID && comment.body.includes("downloading the APK"))
+      let commentResult
+      if (apkComment !== undefined) {
+        commentResult = await api.issues.updateComment({
+          owner, 
+          repo, 
+          comment_id: apkComment.id,
+          body: commentBody
+        })
+      } else {
+        commentResult = await api.issues.createComment({
+          owner,
+          repo,
+          number,
+          body: commentBody
+        })
+      }
+
+      console.log(`APK download comment posted to ${commentResult.data.html_url}`)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.14",
+    "@types/node": "^12.7.2",
     "danger": "^8.0.0",
     "jest": "^24.8.0",
     "jest-junit": "^6.4.0",
@@ -24,5 +25,8 @@
       "jsx",
       "json"
     ]
+  },
+  "dependencies": {
+    "github-webhook-event-types": "^1.2.1"
   }
 }

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -28,6 +28,9 @@
             ],
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
+            ],
+            "status.success": [
+                "Automattic/peril-settings@org/pr/android-installable-build.ts"
             ]
         },
         "woocommerce/woocommerce-ios": {

--- a/tests/android-installable-build-test.ts
+++ b/tests/android-installable-build-test.ts
@@ -1,0 +1,133 @@
+
+import fetch from 'node-fetch'
+jest.mock('node-fetch', () => jest.fn())
+
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import androidInstallableBuild from "../org/pr/android-installable-build";
+
+let mockedArtifacts = []
+
+beforeEach(() => {
+    fetch.mockImplementation(() => {
+        return {
+            ok: true,
+            json: () => { return Promise.resolve(mockedArtifacts) }
+        }
+    })
+
+    dm.danger = {
+        github: {
+          api: {
+            search: {
+              issuesAndPullRequests: jest.fn(),
+            },
+            issues: {
+              createComment: jest.fn(),
+              listComments: jest.fn()
+            },
+            pulls: {
+              get: jest.fn(),
+            }
+          },
+        },
+      }
+
+    ;(global as any).console = {
+        log: jest.fn(),
+    }
+});
+
+describe("installable APK handling", () => {
+    it("bails when its not a success", async () => {
+        await androidInstallableBuild({ state: "fail" } as any)
+        expect(console.log).toBeCalledWith('Not a successful state - got fail')
+    })
+
+    it("bails when its an installable build status", async () => {
+        await androidInstallableBuild({ state: "success", context: "ci/circleci: Tests" } as any)
+        expect(console.log).toBeCalledWith('Not an installable build status check - got ci/circleci: Tests')
+    })
+
+    it("bails when there is no target_url", async () => {
+        await androidInstallableBuild({ state: "success", context: "ci/circleci: Installable Build" } as any)
+        expect(console.log).toBeCalledWith('No target_url on the successful status')
+    })
+
+    it("gets the artifacts for the CircleCI build, and bails when there are none", async () => {
+        mockedArtifacts = []
+
+        await androidInstallableBuild({
+            state: "success",
+            context: "ci/circleci: Installable Build",
+            target_url: "https://circleci.com/gh/Owner/Repo/12345?some=query",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            }
+        } as any)
+        expect(console.log).toBeCalledWith('No APK artifact found on the build')
+    })
+
+    it("gets the artifacts for the CircleCI build, and bails when there are no APK artifacts", async () => {
+        mockedArtifacts = [{
+            path: 'artifact.zip',
+            url: 'https://circleci.com/artifact.zip'
+        }]
+
+        await androidInstallableBuild({
+            state: "success",
+            context: "ci/circleci: Installable Build",
+            target_url: "https://circleci.com/gh/Owner/Repo/12345?some=query",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            }
+        } as any)
+        expect(console.log).toBeCalledWith('No APK artifact found on the build')
+    })
+
+    it("gets the artifacts for the CircleCI build, and comments with the APK artifact", async () => {
+        mockedArtifacts = [{
+            path: 'artifact.apk',
+            url: 'https://circleci.com/artifact.apk'
+        }]
+
+        // Gets a corresponding issue
+        dm.danger.github.api.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve({ data: { items: [{ number: 1 }] } }))
+
+        // No existing comments
+        dm.danger.github.api.issues.listComments.mockReturnValueOnce(Promise.resolve({data: []}))
+
+        // Returns a PR without the right commit
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(
+            Promise.resolve({ data: { head: { sha: "abc" } } })
+        )
+
+        // Comment on the PR
+        dm.danger.github.api.issues.createComment.mockReturnValueOnce(Promise.resolve({data: { html_url: "https://github.com/comment_url" }}))
+
+        await androidInstallableBuild({
+            state: "success",
+            context: "ci/circleci: Installable Build",
+            target_url: "https://circleci.com/gh/Owner/Repo/12345?some=query",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            },
+            commit: { sha: 'abc' }
+        } as any)
+        expect(console.log).toBeCalledWith('Posting comment for artifact.apk at https://circleci.com/artifact.apk')
+        
+        expect(dm.danger.github.api.issues.createComment).toBeCalledWith({
+            owner: 'Owner',
+            repo: 'Repo',
+            number: 1,
+            body: `You can test the changes on this Pull Request by downloading the APK [here](https://circleci.com/artifact.apk).`
+        })
+
+        expect(console.log).toBeCalledWith('APK download comment posted to https://github.com/comment_url')
+    })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,6 +374,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/node@^12.7.2":
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -1308,6 +1313,11 @@ git-config-path@^1.0.1:
     extend-shallow "^2.0.1"
     fs-exists-sync "^0.1.0"
     homedir-polyfill "^1.0.0"
+
+github-webhook-event-types@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/github-webhook-event-types/-/github-webhook-event-types-1.2.1.tgz#3427ec2d7625457ef9c1bac5e929cb59b63bd667"
+  integrity sha512-S0/O8tggnJwNYx4Gp39pgarBjO9/bY5/PAY8zlx8HuacWVULqk05M9wmZ0n42ueN+YSPWx/1BAItBKzv//4GfA==
 
 gitlab@^6.0.0:
   version "6.3.7"


### PR DESCRIPTION
Adds a Peril event that will post a comment on Android PRs with an APK to test. You can see an example of this working [here](https://github.com/wordpress-mobile/WordPress-Android/pull/10404#issuecomment-522626257). Screenshot:

![image](https://user-images.githubusercontent.com/1773641/63278740-c14abc80-c29f-11e9-941c-37d6a39b7ad3.png)

It does this by using the `status.success` webhook as follows:

- If the status check is for a CircleCI build called `Installable Build`, use the CircleCI API to check for APK artifacts.
- Post a comment (or update the existing one) to the PR with a link to download the APK.