### PR TITLE
Add installable build support to WCAndroid

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -48,6 +48,9 @@
                 "Automattic/peril-settings@org/pr/milestone.ts",
                 "Automattic/peril-settings@org/pr/diff-size.ts",
                 "Automattic/peril-settings@org/pr/check-login-subtree.ts"
+            ],
+            "status.success": [
+                "Automattic/peril-settings@org/pr/android-installable-build.ts"
             ]
         },
         "Automattic/simplenote-ios": {


### PR DESCRIPTION
This opts WooCommerce Android into the behaviour added in https://github.com/Automattic/peril-settings/pull/14.

WCAndroid PR is here: https://github.com/woocommerce/woocommerce-android/pull/1387