### PR TITLE
Add installable builds to Simplenote Android

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -70,6 +70,9 @@
             "pull_request, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "status.success": [
+                "Automattic/peril-settings@org/pr/android-installable-build.ts"
             ]
         },
         "Automattic/simplenote-android": {


### PR DESCRIPTION
This is a tiny change to enable the existing installable build handling (reviewed in https://github.com/Automattic/peril-settings/pull/14) to Simplenote Android.

The companion PR is 

We can't really test this until it is merged, but since its already in use for WCAndroid and WPAndroid there isn't any risk involved.