### PR TITLE
Add installable builds to Portkey

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -80,6 +80,11 @@
             "status.success": [
                 "Automattic/peril-settings@org/pr/android-installable-build.ts"
             ]
+        },
+        "Automattic/portkey-android": {
+            "status.success": [
+                "Automattic/peril-settings@org/pr/android-installable-build.ts"
+            ]
         }
     }
 }


### PR DESCRIPTION
This is a tiny change to enable the existing installable build handling (reviewed in https://github.com/Automattic/peril-settings/pull/14) to Portkey Android.

The companion PR is https://github.com/Automattic/portkey-android/pull/179.

We can't really test this until it is merged, but since its already in use for WCAndroid, WPAndroid and Simplenote Android there isn't any risk involved.