### PR TITLE
Add new action to force pending commit statuses to be successful

### DIFF
--- a/org/pr/force-circleci-status.ts
+++ b/org/pr/force-circleci-status.ts
@@ -1,0 +1,35 @@
+import { danger } from "danger"
+import { Status } from "github-webhook-event-types"
+
+// This is a list of the CircleCI statuses to always mark as success
+const FORCED_CONTEXTS: string[] = ["ci/circleci: Installable Build/Hold"]
+
+export default async (status: Status) => {
+    if (status.state !== "pending") {
+      return console.log(
+        `Not a pending state - got ${status.state}`
+      )
+    }
+
+    if (!FORCED_CONTEXTS.includes(status.context)) {
+        return console.log(
+          `Not a status we want to force success - got ${status.context}`
+        )
+    }
+
+    console.log(`Updating ${status.context} state to be success`)
+
+    const owner = status.repository.owner.login
+    const repo = status.repository.name
+
+    const api = danger.github.api
+    await api.repos.createStatus({
+        owner: owner,
+        repo: repo,
+        context: status.context,
+        description: status.description,
+        sha: status.sha,
+        state: "success",
+        target_url: status.target_url
+    })
+}

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -16,6 +16,9 @@
             ],
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
+            ],
+            "status.pending": [
+                "Automattic/peril-settings@org/pr/force-circleci-status.ts"
             ]
         },
         "wordpress-mobile/WordPress-Android": {

--- a/tests/force-circleci-status-test.ts
+++ b/tests/force-circleci-status-test.ts
@@ -1,0 +1,59 @@
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import forceCircleCIStatus from "../org/pr/force-circleci-status";
+
+beforeEach(() => {
+    dm.danger = {
+        github: {
+          api: {
+            repos: {
+                createStatus: jest.fn(),
+            }
+          },
+        },
+      }
+
+    ;(global as any).console = {
+        log: jest.fn(),
+    }
+})
+
+describe("installable APK handling", () => {
+    it("bails when its not a pending status", async () => {
+        await forceCircleCIStatus({ state: "fail" } as any)
+        expect(console.log).toBeCalledWith('Not a pending state - got fail')
+
+        await forceCircleCIStatus({ state: "success" } as any)
+        expect(console.log).toBeCalledWith('Not a pending state - got success')
+    })
+
+    it("bails when its not a context which we want to force", async () => {
+        await forceCircleCIStatus({ state: "pending", context: "ci/circleci: Test" } as any)
+        expect(console.log).toBeCalledWith('Not a status we want to force success - got ci/circleci: Test')
+    })
+
+    it("updates the status to be 'success' when it is the right context", async () => {
+        const webhook: any = {
+            state: "pending",
+            context: "ci/circleci: Installable Build/Hold",
+            description: "Holding build",
+            target_url: "https://circleci.com/workflow-run/abcdefg",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            }
+        }
+        await forceCircleCIStatus(webhook)
+
+        expect(dm.danger.github.api.repos.createStatus).toBeCalledWith({
+            owner: webhook.repository.owner.login,
+            repo: webhook.repository.name,
+            state: "success",
+            context: webhook.context,
+            description: webhook.description,
+            target_url: webhook.target_url,
+        })
+    })
+})


### PR DESCRIPTION
We would like to start taking advantage of CircleCI's [approval feature](https://circleci.com/docs/2.0/workflows/#holding-a-workflow-for-a-manual-approval) so that we can avoid running resource-intensive jobs on every push.

The problem with this is that jobs pending approval show as in progress status checks on Github, which is confusing and misleading. For example, I have added a job pending approval in https://github.com/wordpress-mobile/WordPress-iOS/pull/12654. This is what the PR looks like:

![image (2)](https://user-images.githubusercontent.com/1773641/66559674-af71f100-eb4d-11e9-909c-38a820011331.png)

This adds a small action to Peril to look for a list of statuses with a specific label (e.g. `ci/circleci: Installable Build/Hold`) in the pending state and use the Github API to mark is as successful.

It is difficult to test this without deploying but once the tests are passing I think its safe.