### PR TITLE
Add rule to check for Tracks related changes.

### DIFF
--- a/org/pr/check-tracks.ts
+++ b/org/pr/check-tracks.ts
@@ -1,0 +1,58 @@
+import {message, danger} from "danger";
+
+/*
+    This rule scans a PR for tracks related changes and adds
+    instructions for handling them.
+*/
+async function checkTracksManagementFiles() {
+    // Hard coding the file name to check. 
+    // This can be defined in the repo in the future. 
+    const tracksFiles: string[] = [
+        "AnalyticsTracker.kt",
+        "LoginAnalyticsTracker.kt"
+    ];
+
+    let hasChanges: boolean = false;
+    for (let thisFile of tracksFiles) {
+        // Look for subtree changes in the PR.
+        console.log(`Scanning PR for changes in ${thisFile}.`);
+        hasChanges = hasChanges || danger.git.modified_files.some(f => f.includes(thisFile));
+    }
+
+    return hasChanges;
+}
+
+async function checkCommitDiffs() {
+    let hasChanges: boolean = false;
+    for (let thisFile of danger.git.modified_files) {
+        // Look for subtree changes in the PR.
+        console.log(`Scanning changes in ${thisFile}.`);
+        const diff = await danger.git.diffForFile(thisFile);
+        if (/AnalyticsTracker\.track/.test(diff.diff)) {
+            hasChanges = true;
+        }
+    }
+
+    return hasChanges;
+}
+
+export default async () => {
+    const tracksFileChanged = await checkTracksManagementFiles();
+    const commitDiffs = await checkCommitDiffs();
+
+    if (tracksFileChanged || commitDiffs) {
+        console.log(`Tracks related changes detected: publishing instructions.`);
+        let messageText: string;
+
+        // Put it all together! 
+        messageText = `This PR contains changes to Tracks-related logic. Please ensure the following are completed:\n`;
+        messageText += `**PR Author**\n`;
+        messageText += `[] The PR must be assigned the **Tracks** label\n`;
+        messageText += `**PR Reviewer**\n`;
+        messageText += `[] The tracks events must be validated in the Tracks system.`;
+        messageText += `[] Verify the internal tracks spreadsheet has also been updated.`;
+            
+        message(messageText);
+        console.log(`Done.`);
+    }
+};

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -55,7 +55,8 @@
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
                 "Automattic/peril-settings@org/pr/diff-size.ts",
-                "Automattic/peril-settings@org/pr/check-subtrees.ts"
+                "Automattic/peril-settings@org/pr/check-subtrees.ts",
+                "Automattic/peril-settings@org/pr/check-tracks.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"

--- a/tests/check-tracks-test.ts
+++ b/tests/check-tracks-test.ts
@@ -1,0 +1,60 @@
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import checkTracks from "../org/pr/check-tracks";
+
+// The mocked data and return values for calls the rule makes.
+beforeEach(() => {
+    dm.message = jest.fn().mockReturnValue(true);
+
+    let diffString : string = "diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt\n";
+    diffString += "index eb1a3f999dc..87ac8c3793c 100644\n";
+    diffString += "--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt";
+    diffString += "+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt";
+    diffString += "val latestGCMToken = preferences.getString(FCMRegistrationIntentService.WPCOM_PUSH_DEVICE_TOKEN, null)\n";
+    diffString += "--- AnalyticsTracker.track(stat, properties)";
+    diffString += "+++ AnalyticsTracker.track(stat2, properties)";
+    const mockDiffFromFile = jest.fn();
+    mockDiffFromFile.mockReturnValue(diffString);
+
+    dm.danger = {
+        git: {
+            modified_files: ["AnalyticsTracker.kt"],
+            created_files: [],
+            deleted_files: [],
+            diffForFile: mockDiffFromFile
+        },
+        github: {
+            pr: {
+                head: {
+                    ref: "test-branch",
+                }
+            },
+            thisPR: {
+                repo: "test-wordpress-mobile",
+                number: -1,
+            },
+        },
+    };
+});
+
+describe("tracks checks", () => {
+    it("adds instructions when PR contains changes in AnalyticsTracker.kt", async () => {
+        await checkTracks();
+        
+        // Check that the instructions appear correct.
+        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to Tracks-related logic. Please ensure the following are completed"));
+    })
+
+    it("adds instructions when PR contains changes in LoginAnalyticsTracker.kt", async () => {
+        // Update mocks
+        dm.danger.git.modified_files = ["LoginAnalyticsTracker.kt"];
+        
+        await checkTracks();
+        
+        // Check that the instructions appear correct.
+        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to Tracks-related logic. Please ensure the following are completed"));
+    })
+
+})


### PR DESCRIPTION
This PR adds a `check-tracks` rule that publishes a comment when changes related to `Tracks` are detected. 
The rule is theoretically general, but given the hardcoded file names, it's going to run only for WooCommerce Android. 