### PR TITLE
Run installable builds rule for WCiOS

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -47,6 +47,9 @@
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
                 "Automattic/peril-settings@org/pr/diff-size.ts"
+            ],
+            "status": [
+                "Automattic/peril-settings@org/pr/installable-build.ts"
             ]
         },
         "woocommerce/woocommerce-android": {


### PR DESCRIPTION
This is just a quick opt-in for WCiOS to support installable builds. Until its implemented, it will just do nothing, so no risk here.