### PR TITLE
Adds peril settings for Newspack iOS

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -92,6 +92,11 @@
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"
             ]
+        },
+        "Automattic/newspack-ios": {
+            "status": [
+                "Automattic/peril-settings@org/pr/installable-build.ts"
+            ]
         }
     }
 }


### PR DESCRIPTION
Adds a new setting to support installable builds in Newspack iOS. 