### PR TITLE
Fix artifacts download on private repos

### DIFF
--- a/org/pr/check-tracks.ts
+++ b/org/pr/check-tracks.ts
@@ -43,7 +43,6 @@ async function checkCommitDiffs() {
                 console.log("Danger is no longer defined")
             }
             else {
-                console.log("Danger API Git Object", danger.api.git)
                 console.log("Danger Git Object: ", danger.git)
             }
         }

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -115,6 +115,10 @@ async function getDownloadCommentText(status) {
     if (res.ok) {
       const comment = await res.json()
       return comment.body
+    } else {
+      console.log(
+        `Error while trying to download comment.json: ${res.statusText}`
+      )
     }
   }
 

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -111,7 +111,8 @@ async function getDownloadCommentText(status) {
   const commentJsonArtifact = artifacts.find(artifact => artifact.path.endsWith("comment.json"))
   if (commentJsonArtifact) {
     // Download the JSON file so we can get the comment text
-    const res = await fetch(commentJsonArtifact.url)
+    const commentJsonArtifactUrl = `${commentJsonArtifact.url}?circle-token=${CIRCLECI_TOKEN}`
+    const res = await fetch(commentJsonArtifactUrl)
     if (res.ok) {
       const comment = await res.json()
       return comment.body

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -98,14 +98,6 @@ async function circleCIArtifacts(status) {
 
   const artifactsUrl = `https://circleci.com/api/v1.1/project/gh/${owner}/${repo}/${buildNumber}/artifacts?circle-token=${CIRCLECI_TOKEN}`
 
-  // <Debug: Remove me>
-  const hasToken = CIRCLECI_TOKEN === undefined
-
-  console.log(
-    `Artifacts fetching configuration - '${owner}' - '${repo}' - '${buildNumber}' - '${hasToken}'`
-  )
-  // </Debug: Remove me>
-
   const res = await fetch(artifactsUrl)
   if (res.ok) {
     return res.json()
@@ -117,31 +109,12 @@ async function getDownloadCommentText(status) {
   const artifacts = await circleCIArtifacts(status)
 
   const commentJsonArtifact = artifacts.find(artifact => artifact.path.endsWith("comment.json"))
-
   if (commentJsonArtifact) {
-    // <Debug: Remove me>
-    console.log(
-      `Comment JSON - '${commentJsonArtifact.url}'`
-    )
-    // </Debug: Remove me>
-    
     // Download the JSON file so we can get the comment text
     const res = await fetch(commentJsonArtifact.url)
     if (res.ok) {
       const comment = await res.json()
-      // <Debug: Remove me>
-      console.log(
-        `Comment body: '${comment.body}'`
-        )
-      // </Debug: Remove me>
       return comment.body
-    }
-    else {
-      // <Debug: Remove me>
-      console.log(
-        `Wrong commentJsonArtifact: ${res.statusText}`
-        )
-      // </Debug: Remove me>
     }
   }
 


### PR DESCRIPTION
This PR:
- reverts the additional logging added to debug this issue (but still adds a log entry in a critical point). 
- removes a call to an API that doesn't actually seem to be in the Danger DSL. It was added here: https://github.com/Automattic/peril-settings/commit/0c7b962a56db5a478b6d9beeb498f4f2a1c830ae#diff-e03db42699566c628c96cd4785dde689, but I can't find a reference to it in the DSL: https://danger.systems/js/reference.html#DangerDSLType. Note that this fixes the tests, but only because the endpoint was not mocked. If I'm wrong and the endpoint exists, the proper fix would be to add it to the mocked object.
- adds the auth token to the API call to download artifacts. 

As usual with this repo, there's no easy way to test this. 
I tested locally with an ad-hoc JS script and it fixed the issue for the Newspack-iOS repository without breaking anything for the others :-) 
It's also compliant with the doc here: https://circleci.com/docs/api/#download-an-artifact-file