### PR TITLE
Enable Installable builds for Simplenote iOS

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -71,6 +71,9 @@
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
                 "Automattic/peril-settings@org/pr/diff-size.ts"
+            ],
+            "status": [
+                "Automattic/peril-settings@org/pr/installable-build.ts"
             ]
         },
         "Automattic/simplenote-macos": {


### PR DESCRIPTION
This PR enables Installable Builds for Simplenote iOS. 
There's no easy way to test it, but as long as the JSON syntax is correct, it shouldn't break anything. 