### PR TITLE
Add instructions on how to build and run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Peril Settings
 
 These are the settings for running [Peril](https://github.com/danger/peril) on repositories in `Automattic`, `simplenote` and `wordpress-mobile`.
+
+### Installing
+
+After cloning the repo, run `yarn install`.
+
+### Running the tests
+
+Tests can be run with `yarn test`.


### PR DESCRIPTION
Makes the README a bit more informative, loosely inspired by https://gist.github.com/PurpleBooth/109311bb0361f32d87a2.