### PR TITLE
Fix the "cannot read property 'labels' of undefined" error

### DIFF
--- a/org/pr/ios-macos.ts
+++ b/org/pr/ios-macos.ts
@@ -3,7 +3,8 @@ import {message, warn, fail, danger} from "danger";
 export default async () => {
 
     const pr = danger.github.pr;
-
+    const githubLabels = danger.github.issue.labels;
+    
     // Core Data Model Safety Checks
     const targetReleaseBranch = pr.base.ref.startsWith("release/");
     const modifiedFiles = danger.git.modified_files;
@@ -32,7 +33,6 @@ export default async () => {
     }
 
     // Let users know that we're skipping tests on release PRs
-    const githubLabels = danger.github.issue.labels;
     const isReleasePr = (githubLabels.length != 0) && githubLabels.some(label => label.name.includes("Releases"));
     if (isReleasePr) {
         message("This PR has the 'Releases' label: some checks will be skipped.");


### PR DESCRIPTION
This PR is an attempt to fix the "Cannot read property 'labels' of undefined" we've been seeing lately. 

Since it looks like the `labels` property sometimes isn't available after some time, this PR tries to get it when the action is triggered. 

I'm not totally sure this will fix the issue, but based on experiences we had with similar issues in the past, it _may_ do the trick. 