### PR TITLE
Post comment with link to trigger optional tests on PRs

### DIFF
--- a/org/pr/optional-tests.ts
+++ b/org/pr/optional-tests.ts
@@ -1,0 +1,95 @@
+import { danger } from "danger"
+import { Status } from "github-webhook-event-types"
+
+const CIRCLECI_TOKEN: string = process.env['CIRCLECI_TOKEN']
+const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
+
+// This is a list of the CircleCI statuses to process
+const HOLD_CONTEXTS: string[] = ["ci/circleci: Optional Tests/Hold"]
+
+async function markStatusAsSuccess(status) {
+  console.log(`Updating ${status.context} state to be success`)
+
+  const owner = status.repository.owner.login
+  const repo = status.repository.name
+
+  const api = danger.github.api
+  await api.repos.createStatus({
+      owner: owner,
+      repo: repo,
+      context: status.context,
+      description: status.description,
+      sha: status.sha,
+      state: "success",
+      target_url: status.target_url
+  })
+}
+
+async function getPRsWithStatus(status) {
+  const api = danger.github.api
+
+  // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
+  const repoString = status.repository.full_name
+  const searchResponse = await api.search.issuesAndPullRequests({ q: `${status.commit.sha} type:pr is:open repo:${repoString}` })
+
+  // https://developer.github.com/v3/search/#search-issues
+  const prsWithCommit = searchResponse.data.items.map((i: any) => i.number) as number[]
+  if (prsWithCommit.length === 0) {
+    console.log(`No open PR found for this commit ${status.commit.sha}`)
+    return []
+  }
+  return prsWithCommit
+}
+
+export async function createOrUpdateComment(status, message) {
+  const api = danger.github.api
+  const owner = status.repository.owner.login
+  const repo = status.repository.name
+
+  // Add a prefix to our comment so we can easily find/update it later.
+  const commentPrefix = "<!--- Optional Tests Comment --->"
+  const commentBody = `${commentPrefix}\n${message}`
+
+  // Since a commit can be on more than one PR, find all PRs that have this commit
+  const prsWithStatus = await getPRsWithStatus(status)
+  for (const number of prsWithStatus) {
+    const pull = await api.pulls.get({ owner, repo, number })
+    if (pull.data.head.sha !== status.commit.sha) {
+      console.log(`${status.commit.sha} is not the latest commit on PR ${number}, skipping comment`)
+      continue
+    }
+
+    const allComments = await api.issues.listComments({owner, repo, number})
+
+    const existingComment = allComments.data.find(comment => comment.user.id === PERIL_BOT_USER_ID && comment.body.includes(commentPrefix))
+    let commentResult
+    if (existingComment !== undefined) {
+      commentResult = await api.issues.updateComment({
+        owner,
+        repo,
+        comment_id: existingComment.id,
+        body: commentBody
+      })
+    } else {
+      commentResult = await api.issues.createComment({
+        owner,
+        repo,
+        number,
+        body: commentBody
+      })
+    }
+
+    console.log(`Optional tests comment posted to ${commentResult.data.html_url}`)
+  }
+}
+
+export default async (status: Status) => {
+    if (status.state == "pending" && HOLD_CONTEXTS.includes(status.context)) {
+      await markStatusAsSuccess(status)
+      await createOrUpdateComment(status, `You can trigger optional UI/connected tests for these changes by visiting CircleCI [here](${status.target_url}).`)
+    } else {
+      return console.log(
+        `Not a status we want to process for optional tests - got '${status.context}' (${status.state})`
+      )
+    }
+}

--- a/tests/optional-tests-test.ts
+++ b/tests/optional-tests-test.ts
@@ -1,0 +1,92 @@
+
+jest.mock('node-fetch', () => jest.fn())
+
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import optionalTests from "../org/pr/optional-tests";
+
+beforeEach(() => {
+    dm.danger = {
+        github: {
+          api: {
+            repos: {
+                createStatus: jest.fn(),
+            },
+            search: {
+              issuesAndPullRequests: jest.fn(),
+            },
+            issues: {
+              createComment: jest.fn(),
+              listComments: jest.fn()
+            },
+            pulls: {
+              get: jest.fn(),
+            }
+          },
+        },
+      }
+
+    ;(global as any).console = {
+        log: jest.fn()
+    }
+
+    // Mock Github API for posting comments
+    // Gets a corresponding issue
+    dm.danger.github.api.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve({ data: { items: [{ number: 1 }] } }))
+    // No existing comments
+    dm.danger.github.api.issues.listComments.mockReturnValueOnce(Promise.resolve({data: []}))
+    // Returns a PR with the right commit
+    dm.danger.github.api.pulls.get.mockReturnValueOnce(
+        Promise.resolve({ data: { head: { sha: "abc" } } })
+    )
+    // Mock commenting on the PR
+    dm.danger.github.api.issues.createComment.mockReturnValueOnce(Promise.resolve({data: { html_url: "https://github.com/comment_url" }}))
+})
+
+const expectComment = (webhook, commentBody) => {
+  expect(dm.danger.github.api.issues.createComment).toBeCalledWith({
+    owner: webhook.repository.owner.login,
+    repo: webhook.repository.name,
+    number: 1,
+    body: `<!--- Optional Tests Comment --->\n${commentBody}`
+  })
+  expect(console.log).toBeCalledWith('Optional tests comment posted to https://github.com/comment_url')
+}
+
+describe("optional test handling", () => {
+    it("bails when its not a status/state we want to handle", async () => {
+        await optionalTests({ state: "fail", context: "Failure context" } as any)
+        expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'Failure context' (fail)")
+
+        await optionalTests({ state: "success", context: "ci/circleci: Optional Tests/Hold" } as any)
+        expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Optional Tests/Hold' (success)")
+    })
+
+    it("updates the status to be 'success' when it is the right context, and comments", async () => {
+        const webhook: any = {
+            state: "pending",
+            context: "ci/circleci: Optional Tests/Hold",
+            description: "Holding build",
+            target_url: "https://circleci.com/workflow-run/abcdefg",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            },
+            commit: { sha: 'abc' }
+        }
+        await optionalTests(webhook)
+
+        expect(dm.danger.github.api.repos.createStatus).toBeCalledWith({
+            owner: webhook.repository.owner.login,
+            repo: webhook.repository.name,
+            state: "success",
+            context: webhook.context,
+            description: webhook.description,
+            target_url: webhook.target_url,
+        })
+
+        expectComment(webhook, `You can trigger optional UI/connected tests for these changes by visiting CircleCI [here](${webhook.target_url}).`)
+    })
+})


### PR DESCRIPTION
This change is based on the existing Installable Build setup, to support optional test runs on PRs. This PR makes the following changes:

* Forces a `success` status for `Optional Tests/Hold` checks on PRs (so the check doesn't remain in pending status on the PR).
* Posts a comment to the PR with a link to the CircleCI workflow, so the optional tests can be started. Comment text: "You can trigger optional UI/connected tests for these changes by visiting CircleCI here."
* Adds tests for these changes to this repo.

Once the `Optional Tests/Hold` job is started, any jobs that rely on it (i.e. the optional UI/connected tests) will start running and report the test results on the PR.