### PR TITLE
Enable optional tests comment in WordPress repos

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -18,7 +18,8 @@
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
             "status": [
-                "Automattic/peril-settings@org/pr/installable-build.ts"
+                "Automattic/peril-settings@org/pr/installable-build.ts",
+                "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
         "wordpress-mobile/WordPress-Android": {
@@ -33,7 +34,8 @@
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
             "status": [
-                "Automattic/peril-settings@org/pr/installable-build.ts"
+                "Automattic/peril-settings@org/pr/installable-build.ts",
+                "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
         "wordpress-mobile/gutenberg-mobile": {


### PR DESCRIPTION
This enables the optional tests changes from https://github.com/Automattic/peril-settings/pull/39 in the `wordpress-mobile/WordPress-Android` and `wordpress-mobile/WordPress-iOS` repos.

To test: Confirm tests pass.