### PR TITLE
Update optional tests settings for WPiOS

### DIFF
--- a/org/pr/optional-tests.ts
+++ b/org/pr/optional-tests.ts
@@ -5,7 +5,7 @@ const CIRCLECI_TOKEN: string = process.env['CIRCLECI_TOKEN']
 const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
 
 // This is a list of the CircleCI statuses to process
-const HOLD_CONTEXTS: string[] = ["ci/circleci: Optional Tests/Hold"]
+const HOLD_CONTEXTS: string[] = ["ci/circleci: Optional Tests/Hold", "ci/circleci: wordpress_ios/Optional Tests"]
 
 async function markStatusAsSuccess(status) {
   console.log(`Updating ${status.context} state to be success`)


### PR DESCRIPTION
This PR adds another CircleCI status to process for the Optional Tests settings in `/org/pr/optional-tests.ts`. This is due to the CircleCI workflow setup on iOS, for example in https://github.com/wordpress-mobile/WordPress-iOS/pull/13785.