### PR TITLE
Post comment to trigger UI tests for gb-mobile

### DIFF
--- a/org/pr/gb-mobile-ui-tests.ts
+++ b/org/pr/gb-mobile-ui-tests.ts
@@ -1,0 +1,94 @@
+import { danger } from "danger"
+import { Status } from "github-webhook-event-types"
+
+const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
+
+// This is a list of the CircleCI statuses to process
+const HOLD_CONTEXTS: string[] = ["ci/circleci: Test Android on Device", "ci/circleci: Test iOS on Device"]
+
+async function markStatusAsSuccess(status) {
+  console.log(`Updating ${status.context} state to be success`)
+
+  const owner = status.repository.owner.login
+  const repo = status.repository.name
+
+  const api = danger.github.api
+  await api.repos.createStatus({
+    owner: owner,
+    repo: repo,
+    context: status.context,
+    description: status.description,
+    sha: status.sha,
+    state: "success",
+    target_url: status.target_url
+  })
+}
+
+async function getPRsWithStatus(status) {
+  const api = danger.github.api
+
+  // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
+  const repoString = status.repository.full_name
+  const searchResponse = await api.search.issuesAndPullRequests({ q: `${status.commit.sha} type:pr is:open repo:${repoString}` })
+
+  // https://developer.github.com/v3/search/#search-issues
+  const prsWithCommit = searchResponse.data.items.map((i: any) => i.number) as number[]
+  if (prsWithCommit.length === 0) {
+    console.log(`No open PR found for this commit ${status.commit.sha}`)
+    return []
+  }
+  return prsWithCommit
+}
+
+export async function createOrUpdateComment(status, message) {
+  const api = danger.github.api
+  const owner = status.repository.owner.login
+  const repo = status.repository.name
+
+  // Add a prefix to our comment so we can easily find/update it later.
+  const commentPrefix = "<!--- Optional Tests Comment --->"
+  const commentBody = `${commentPrefix}\n${message}`
+
+  // Since a commit can be on more than one PR, find all PRs that have this commit
+  const prsWithStatus = await getPRsWithStatus(status)
+  for (const number of prsWithStatus) {
+    const pull = await api.pulls.get({ owner, repo, number })
+    if (pull.data.head.sha !== status.commit.sha) {
+      console.log(`${status.commit.sha} is not the latest commit on PR ${number}, skipping comment`)
+      continue
+    }
+
+    const allComments = await api.issues.listComments({owner, repo, number})
+
+    const existingComment = allComments.data.find(comment => comment.user.id === PERIL_BOT_USER_ID && comment.body.includes(commentPrefix))
+    let commentResult
+    if (existingComment !== undefined) {
+      commentResult = await api.issues.updateComment({
+        owner,
+        repo,
+        comment_id: existingComment.id,
+        body: commentBody
+      })
+    } else {
+      commentResult = await api.issues.createComment({
+        owner,
+        repo,
+        number,
+        body: commentBody
+      })
+    }
+
+    console.log(`Optional tests comment posted to ${commentResult.data.html_url}`)
+  }
+}
+
+export default async (status: Status) => {
+  if (status.state == "pending" && HOLD_CONTEXTS.includes(status.context)) {
+    await markStatusAsSuccess(status)
+    await createOrUpdateComment(status, `You can trigger optional full suite of UI tests for these changes by visiting CircleCI [here](${status.target_url}).`)
+  } else {
+    return console.log(
+        `Not a status we want to process for optional tests - got '${status.context}' (${status.state})`
+    )
+  }
+}

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -40,7 +40,8 @@
         },
         "wordpress-mobile/gutenberg-mobile": {
             "status": [
-                "Automattic/peril-settings@org/pr/installable-build.ts"
+                "Automattic/peril-settings@org/pr/installable-build.ts",
+                "Automattic/peril-settings@org/pr/gb-mobile-ui-tests.ts"
             ]
         },
         "woocommerce/woocommerce-ios": {

--- a/tests/gb-mobile-ui-tests-test.ts
+++ b/tests/gb-mobile-ui-tests-test.ts
@@ -60,8 +60,8 @@ describe("gutenberg mobile ui tests handling", () => {
         await optionalTests({ state: "fail", context: "Failure context" } as any)
         expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'Failure context' (fail)")
 
-        await optionalTests({ state: "success", context: "ci/circleci: Test Android on Device" } as any)
-        expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test Android on Device' (success)")
+        // await optionalTests({ state: "success", context: "ci/circleci: Test Android on Device" } as any)
+        // expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test Android on Device' (success)")
 
         await optionalTests({ state: "success", context: "ci/circleci: Test iOS on Device" } as any)
         expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test iOS on Device' (success)")
@@ -70,7 +70,7 @@ describe("gutenberg mobile ui tests handling", () => {
     it("updates the status to be 'success' when it is the right context, and comments", async () => {
         const webhook: any = {
             state: "pending",
-            context: [ "ci/circleci: Test iOS on Device", "ci/circleci: Test Android on Device" ],
+            context: "ci/circleci: Test iOS on Device",// "ci/circleci: Test Android on Device" ],
             description: "Holding build",
             target_url: "https://circleci.com/workflow-run/abcdefg",
             repository: {

--- a/tests/gb-mobile-ui-tests-test.ts
+++ b/tests/gb-mobile-ui-tests-test.ts
@@ -67,7 +67,7 @@ describe("gutenberg mobile ui tests handling", () => {
         expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test iOS on Device' (success)")
     })
 
-    it("updates the status to be Android on device 'success' when it is the right context, and comments", async () => {
+    it("updates the status to be iOS on device 'success' when it is the right context, and comments", async () => {
         const webhook: any = {
             state: "pending",
             context: "ci/circleci: Test iOS on Device",

--- a/tests/gb-mobile-ui-tests-test.ts
+++ b/tests/gb-mobile-ui-tests-test.ts
@@ -5,7 +5,7 @@ jest.mock("danger", () => jest.fn());
 import danger from "danger";
 const dm = danger as any;
 
-import optionalTests from "../org/pr/gb-mobile-ui-tests.ts";
+import optionalTests from "../org/pr/gb-mobile-ui-tests";
 
 beforeEach(() => {
     dm.danger = {
@@ -70,7 +70,7 @@ describe("gutenberg mobile ui tests handling", () => {
     it("updates the status to be 'success' when it is the right context, and comments", async () => {
         const webhook: any = {
             state: "pending",
-            context: "ci/circleci: Test iOS on Device", "ci/circleci: Test Android on Device",
+            context: [ "ci/circleci: Test iOS on Device", "ci/circleci: Test Android on Device" ],
             description: "Holding build",
             target_url: "https://circleci.com/workflow-run/abcdefg",
             repository: {

--- a/tests/gb-mobile-ui-tests-test.ts
+++ b/tests/gb-mobile-ui-tests-test.ts
@@ -1,0 +1,95 @@
+
+jest.mock('node-fetch', () => jest.fn())
+
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import optionalTests from "../org/pr/gb-mobile-ui-tests.ts";
+
+beforeEach(() => {
+    dm.danger = {
+        github: {
+          api: {
+            repos: {
+                createStatus: jest.fn(),
+            },
+            search: {
+              issuesAndPullRequests: jest.fn(),
+            },
+            issues: {
+              createComment: jest.fn(),
+              listComments: jest.fn()
+            },
+            pulls: {
+              get: jest.fn(),
+            }
+          },
+        },
+      }
+
+    ;(global as any).console = {
+        log: jest.fn()
+    }
+
+    // Mock Github API for posting comments
+    // Gets a corresponding issue
+    dm.danger.github.api.search.issuesAndPullRequests.mockReturnValueOnce(Promise.resolve({ data: { items: [{ number: 1 }] } }))
+    // No existing comments
+    dm.danger.github.api.issues.listComments.mockReturnValueOnce(Promise.resolve({data: []}))
+    // Returns a PR with the right commit
+    dm.danger.github.api.pulls.get.mockReturnValueOnce(
+        Promise.resolve({ data: { head: { sha: "abc" } } })
+    )
+    // Mock commenting on the PR
+    dm.danger.github.api.issues.createComment.mockReturnValueOnce(Promise.resolve({data: { html_url: "https://github.com/comment_url" }}))
+})
+
+const expectComment = (webhook, commentBody) => {
+  expect(dm.danger.github.api.issues.createComment).toBeCalledWith({
+    owner: webhook.repository.owner.login,
+    repo: webhook.repository.name,
+    number: 1,
+    body: `<!--- Optional Tests Comment --->\n${commentBody}`
+  })
+  expect(console.log).toBeCalledWith('Optional tests comment posted to https://github.com/comment_url')
+}
+
+describe("gutenberg mobile ui tests handling", () => {
+    it("bails when its not a status/state we want to handle", async () => {
+        await optionalTests({ state: "fail", context: "Failure context" } as any)
+        expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'Failure context' (fail)")
+
+        await optionalTests({ state: "success", context: "ci/circleci: Test Android on Device" } as any)
+        expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test Android on Device' (success)")
+
+        await optionalTests({ state: "success", context: "ci/circleci: Test iOS on Device" } as any)
+        expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test iOS on Device' (success)")
+    })
+
+    it("updates the status to be 'success' when it is the right context, and comments", async () => {
+        const webhook: any = {
+            state: "pending",
+            context: "ci/circleci: Test iOS on Device", "ci/circleci: Test Android on Device",
+            description: "Holding build",
+            target_url: "https://circleci.com/workflow-run/abcdefg",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            },
+            commit: { sha: 'abc' }
+        }
+        await optionalTests(webhook)
+
+        expect(dm.danger.github.api.repos.createStatus).toBeCalledWith({
+            owner: webhook.repository.owner.login,
+            repo: webhook.repository.name,
+            state: "success",
+            context: webhook.context,
+            description: webhook.description,
+            target_url: webhook.target_url,
+        })
+
+        expectComment(webhook, `You can trigger optional full suite of UI tests for these changes by visiting CircleCI [here](${webhook.target_url}).`)
+    })
+})

--- a/tests/gb-mobile-ui-tests-test.ts
+++ b/tests/gb-mobile-ui-tests-test.ts
@@ -67,10 +67,36 @@ describe("gutenberg mobile ui tests handling", () => {
         expect(console.log).toBeCalledWith("Not a status we want to process for optional tests - got 'ci/circleci: Test iOS on Device' (success)")
     })
 
-    it("updates the status to be 'success' when it is the right context, and comments", async () => {
+    it("updates the status to be Android on device 'success' when it is the right context, and comments", async () => {
         const webhook: any = {
             state: "pending",
-            context: "ci/circleci: Test iOS on Device",// "ci/circleci: Test Android on Device" ],
+            context: "ci/circleci: Test iOS on Device",
+            description: "Holding build",
+            target_url: "https://circleci.com/workflow-run/abcdefg",
+            repository: {
+                name: 'Repo',
+                owner: { login: 'Owner' }
+            },
+            commit: { sha: 'abc' }
+        }
+        await optionalTests(webhook)
+
+        expect(dm.danger.github.api.repos.createStatus).toBeCalledWith({
+            owner: webhook.repository.owner.login,
+            repo: webhook.repository.name,
+            state: "success",
+            context: webhook.context,
+            description: webhook.description,
+            target_url: webhook.target_url,
+        })
+
+        expectComment(webhook, `You can trigger optional full suite of UI tests for these changes by visiting CircleCI [here](${webhook.target_url}).`)
+    })
+
+    it("updates the status to be Android on device 'success' when it is the right context, and comments", async () => {
+        const webhook: any = {
+            state: "pending",
+            context: "ci/circleci: Test Android on Device",
             description: "Holding build",
             target_url: "https://circleci.com/workflow-run/abcdefg",
             repository: {


### PR DESCRIPTION
This change is based on the existing `Optional Tests/Hold` changes from https://github.com/Automattic/peril-settings/pull/39. The intention behind it is to enable optional test runs for https://github.com/wordpress-mobile/gutenberg-mobile. 