### PR TITLE
Update subtree check to remove check for WordPressMocks changes

### DIFF
--- a/org/pr/check-subtrees.ts
+++ b/org/pr/check-subtrees.ts
@@ -15,10 +15,6 @@ export default async () => {
     const subtrees: Subtree[] = [{
         repo: "wordpress-mobile/WordPress-Login-Flow-Android",
         path: "libs/login/"
-    },
-    {
-        repo: "wordpress-mobile/WordPressMocks",
-        path: "libs/mocks/"
     }];
 
     const modifiedFiles = danger.git.modified_files;

--- a/tests/check-subtrees.test.ts
+++ b/tests/check-subtrees.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
     dm.danger = {
         git: {
-            modified_files: ["libs/login/modified-file.txt", "libs/mocks/other-file.txt"],
+            modified_files: ["libs/login/modified-file.txt"],
             created_files: [],
             deleted_files: [],
         },
@@ -34,16 +34,6 @@ describe("subtree checks", () => {
         
         // First, check that the merge instructions appear correct.
         expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/login/`. It is your responsibility to ensure these changes are merged back into `wordpress-mobile/WordPress-Login-Flow-Android`."));
-        
-        // Then, ensure a piece of mock data is present.
-        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
-    })
-
-    it("adds merge instructions when PR contains changes in libs/mocks/", async () => {
-        await checkSubtrees();
-        
-        // First, check that the merge instructions appear correct.
-        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/mocks/`. It is your responsibility to ensure these changes are merged back into `wordpress-mobile/WordPressMocks`."));
         
         // Then, ensure a piece of mock data is present.
         expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));


### PR DESCRIPTION
We have agreed to stop trying to share WordPressMocks between WPAndroid and WPiOS (internal ref: paaHJt-PH-p2). For now we will continue to use the `wordpress-mobile/WordPressMocks` repo as the iOS mocks pod and let WPAndroid diverge from it.

The changes in this PR will allow WPAndroid to diverge by removing the reminder to merge mocks changes upstream.

To test: Confirm changes look reasonable and tests pass.