### PR TITLE
Enable optional tests for WooCommerce iOS

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -52,7 +52,8 @@
                 "Automattic/peril-settings@org/pr/diff-size.ts"
             ],
             "status": [
-                "Automattic/peril-settings@org/pr/installable-build.ts"
+                "Automattic/peril-settings@org/pr/installable-build.ts",
+                "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
         "woocommerce/woocommerce-android": {


### PR DESCRIPTION
This enables the optional tests setup in the `woocommerce/woocommerce-ios` repo.

You can see an example PR that would use this setup (with the check `ci/circleci: Optional Tests/Hold`) here: https://github.com/woocommerce/woocommerce-ios/pull/2214