### PR TITLE
Disable milestone check for draft PRs and wip features

### DIFF
--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -3,6 +3,7 @@ import {warn, danger} from "danger";
 export default async () => {
     // Skip for release PRs and PRs against feature branches
     const githubLabels = danger.github.issue.labels;
+    const pr = danger.github.pr;
 
     if (githubLabels.length != 0) {
         const releases = githubLabels.some(label => label.name.includes("Releases"));
@@ -10,8 +11,10 @@ export default async () => {
             return;
         }
 
+        const targetsDevelop = pr.base.ref == "develop";
+        const targetsRelease = pr.base.ref.startsWith("release/");
         const wipFeature = githubLabels.some(label => label.name.includes("Part of a WIP Feature"));
-        if (wipFeature) {
+        if (!targetsDevelop && !targetsRelease && wipFeature) {
             return;
         }
     }

--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -1,18 +1,24 @@
 import {warn, danger} from "danger";
 
 export default async () => {
-    // Skip for release PRs and PRs against feature branches
     const githubLabels = danger.github.issue.labels;
-    const pr = danger.github.pr;
+    const currentPR = await danger.github.api.pulls.get(danger.github.thisPR);
+
+    // Skip for draft PRs
+    if (currentPR.data.draft) {
+        return;
+    }
 
     if (githubLabels.length != 0) {
+        // Skip for PRs with "Releases" label
         const releases = githubLabels.some(label => label.name.includes("Releases"));
         if (releases) {
             return;
         }
 
-        const targetsDevelop = pr.base.ref == "develop";
-        const targetsRelease = pr.base.ref.startsWith("release/");
+        // Skip for PRs for wip features unless the PR is against "develop" or "release/x.x" branches
+        const targetsDevelop = danger.github.pr.base.ref == "develop";
+        const targetsRelease = danger.github.pr.base.ref.startsWith("release/");
         const wipFeature = githubLabels.some(label => label.name.includes("Part of a WIP Feature"));
         if (!targetsDevelop && !targetsRelease && wipFeature) {
             return;
@@ -20,8 +26,7 @@ export default async () => {
     }
 
     // Warn if the PR doesn't have a milestone
-    const issue = await danger.github.api.issues.get(danger.github.thisPR);
-    if (issue.data.milestone == null) {
+    if (currentPR.data.milestone == null) {
         warn("PR is not assigned to a milestone.");
     }
 };

--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -1,16 +1,18 @@
 import {warn, danger} from "danger";
 
 export default async () => {
-    // Skip for release PRs
+    // Skip for release PRs and PRs against feature branches
     const githubLabels = danger.github.issue.labels;
 
     if (githubLabels.length != 0) {
         const releases = githubLabels.some(label => label.name.includes("Releases"));
-        if (releases) {
+        const featureGroup = githubLabels.some(label => label.name.includes("Part of a Feature Group"));
+        const wipFeature = githubLabels.some(label => label.name.includes("WIP Feature"));
+        if (releases || (featureGroup && wipFeature)) {
             return;
         }
     }
-  
+
     // Warn if the PR doesn't have a milestone
     const issue = await danger.github.api.issues.get(danger.github.thisPR);
     if (issue.data.milestone == null) {

--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -6,9 +6,12 @@ export default async () => {
 
     if (githubLabels.length != 0) {
         const releases = githubLabels.some(label => label.name.includes("Releases"));
-        const featureGroup = githubLabels.some(label => label.name.includes("Part of a Feature Group"));
-        const wipFeature = githubLabels.some(label => label.name.includes("WIP Feature"));
-        if (releases || (featureGroup && wipFeature)) {
+        if (releases) {
+            return;
+        }
+
+        const wipFeature = githubLabels.some(label => label.name.includes("Part of a WIP Feature"));
+        if (wipFeature) {
             return;
         }
     }

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
     dm.danger = {
         github: {
             api: {
-                issues: {
+                pulls: {
                     get: jest.fn(),
                 },
             },
@@ -29,7 +29,8 @@ beforeEach(() => {
 
 describe("PR milestone checks", () => {
     it("warns with missing milestone", async () => {
-        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+        const mockData = { data: { draft: false, milestone: null } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
 
         await milestone();
 
@@ -37,15 +38,27 @@ describe("PR milestone checks", () => {
     })
 
     it("does not warn when the milestone is present", async () => {
-        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: [{ number: 1 }] } }))
+        const mockData = { data: { draft: false, milestone: [{ number: 1 }] } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
 
         await milestone();
 
         expect(dm.warn).not.toHaveBeenCalled();
     })
 
+    it("does not warn with missing milestone and draft PR", async () => {
+        const mockData = { data: { draft: true, milestone: null } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
+
+        await milestone();
+
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
+
+
     it("does not warn with missing milestone and releases label", async () => {
-        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+        const mockData = { data: { draft: false, milestone: null } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
 
         dm.danger.github.issue.labels = [
             {
@@ -59,7 +72,8 @@ describe("PR milestone checks", () => {
     })
 
     it("warns with missing milestone and wip feature label if the base branch is develop", async () => {
-        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+        const mockData = { data: { draft: false, milestone: null } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
 
         dm.danger.github.issue.labels = [
             {
@@ -74,7 +88,8 @@ describe("PR milestone checks", () => {
     })
 
     it("warns with missing milestone and wip feature label if the base branch is release", async () => {
-        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+        const mockData = { data: { draft: false, milestone: null } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
 
         dm.danger.github.issue.labels = [
             {
@@ -89,7 +104,8 @@ describe("PR milestone checks", () => {
     })
 
     it("does not warn with missing milestone and wip feature label", async () => {
-        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+        const mockData = { data: { draft: false, milestone: null } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
 
         dm.danger.github.issue.labels = [
             {

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -17,6 +17,11 @@ beforeEach(() => {
             },
             issue: {
                 labels: [],
+            },
+            pr: {
+                base: {
+                    ref: "",
+                },
             }
         },
     };
@@ -51,6 +56,36 @@ describe("PR milestone checks", () => {
         await milestone();
 
         expect(dm.warn).not.toHaveBeenCalled();
+    })
+
+    it("warns with missing milestone and wip feature label if the base branch is develop", async () => {
+        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+
+        dm.danger.github.issue.labels = [
+            {
+                name: 'Part of a WIP Feature',
+            },
+        ]
+        dm.danger.github.pr.base.ref="develop";
+
+        await milestone();
+
+        expect(dm.warn).toHaveBeenCalledWith("PR is not assigned to a milestone.");
+    })
+
+    it("warns with missing milestone and wip feature label if the base branch is release", async () => {
+        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+
+        dm.danger.github.issue.labels = [
+            {
+                name: 'Part of a WIP Feature',
+            },
+        ]
+        dm.danger.github.pr.base.ref="release/1.2";
+
+        await milestone();
+
+        expect(dm.warn).toHaveBeenCalledWith("PR is not assigned to a milestone.");
     })
 
     it("does not warn with missing milestone and wip feature label", async () => {

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -27,7 +27,7 @@ describe("PR milestone checks", () => {
         dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
 
         await milestone();
-        
+
         expect(dm.warn).toHaveBeenCalledWith("PR is not assigned to a milestone.");
     })
 
@@ -35,11 +35,11 @@ describe("PR milestone checks", () => {
         dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: [{ number: 1 }] } }))
 
         await milestone();
-        
+
         expect(dm.warn).not.toHaveBeenCalled();
     })
 
-    it("does not warns with missing milestone and releases label", async () => {
+    it("does not warn with missing milestone and releases label", async () => {
         dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
 
         dm.danger.github.issue.labels = [
@@ -49,7 +49,24 @@ describe("PR milestone checks", () => {
         ]
 
         await milestone();
-        
+
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
+
+    it("does not warn with missing milestone and feature group labels", async () => {
+        dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
+
+        dm.danger.github.issue.labels = [
+            {
+                name: 'Part of a Feature Group',
+            },
+            {
+                name: 'WIP Feature'
+            }
+        ]
+
+        await milestone();
+
         expect(dm.warn).not.toHaveBeenCalled();
     })
 })

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -53,16 +53,13 @@ describe("PR milestone checks", () => {
         expect(dm.warn).not.toHaveBeenCalled();
     })
 
-    it("does not warn with missing milestone and feature group labels", async () => {
+    it("does not warn with missing milestone and wip feature label", async () => {
         dm.danger.github.api.issues.get.mockReturnValueOnce(Promise.resolve({ data: { milestone: null } }))
 
         dm.danger.github.issue.labels = [
             {
-                name: 'Part of a Feature Group',
+                name: 'Part of a WIP Feature',
             },
-            {
-                name: 'WIP Feature'
-            }
         ]
 
         await milestone();


### PR DESCRIPTION
This PR disables the milestone check in certain conditions. If the PR is a draft, we always skip the check. This should give developers more flexibility for when they are actively working on a PR. There is now an optional label `Part of a WIP Feature` which will only disable the check if the base branch is **not** `develop` or `release/{version}`.

Disabling this check for wip features was something requested by developers and @elibud gave 👍 as long as it doesn't affect regular PRs. Since a PR needs to be merged to `develop` or a release branch before it can be shipped, I can't think of a scenario where we might miss this check with this setup. I am even questioning whether the extra label is necessary and if we should just disable the milestone checks for PRs unless they are being merged to `develop` or release branches.

If we do keep the label, I am finding it hard to find a good name for it, so if you have any suggestions to change `Part of a WIP Feature`, I'd be all for it.

I added a bunch of unit tests for these, but I still don't know what is the best way to test this without merging or using a temporary github project. (which would require setup time I'd prefer to avoid) @mokagio I think you have some experience in this area, any ideas?

_I am opening this as a draft PR because I'd like to coordinate an announcement p2 post with it. Please do review it, but don't merge it yet. Thank you!_

