### PR TITLE
Adds subtree checks for libs/utils

### DIFF
--- a/org/pr/check-subtrees.ts
+++ b/org/pr/check-subtrees.ts
@@ -15,6 +15,10 @@ export default async () => {
     const subtrees: Subtree[] = [{
         repo: "wordpress-mobile/WordPress-Login-Flow-Android",
         path: "libs/login/"
+    },
+    {
+        repo: "wordpress-mobile/WordPress-Utils-Android",
+        path: "libs/utils/"
     }];
 
     const modifiedFiles = danger.git.modified_files;
@@ -34,21 +38,21 @@ export default async () => {
 
             // Handy accessor for some PR info.
             const pr = danger.github.thisPR;
-            
+
             // The name of the branch that the `subtree push` command will create.
             const mergeBranch = `merge/${pr.repo}/${pr.number}`;
 
             // The merge instructions.
             let markdownText: string;
 
-            // Put it all together! 
+            // Put it all together!
             markdownText = `This PR contains changes in the subtree \`${subtree.path}\`. It is your responsibility to ensure these changes are merged back into \`${subtree.repo}\`.  Follow these handy steps!\n`;
             markdownText += `WARNING: *Make sure your git version is 2.19.x or lower* - there is currently a bug in later versions that will corrupt the subtree history!\n`;
             markdownText += `1. \`cd ${pr.repo}\`\n`;
             markdownText += `2. \`git checkout ${danger.github.pr.head.ref}\`\n`;
             markdownText += `3. \`git subtree push --prefix=${subtree.path} https://github.com/${subtree.repo}.git ${mergeBranch}\`\n`;
             markdownText += `4. Browse to https://github.com/${subtree.repo}/pull/new/${mergeBranch} and open a new PR.`;
-            
+
             message(markdownText);
         }
 

--- a/tests/check-subtrees.test.ts
+++ b/tests/check-subtrees.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
     dm.danger = {
         git: {
-            modified_files: ["libs/login/modified-file.txt"],
+            modified_files: ["libs/login/modified-file.txt", "libs/utils/other-file.txt"],
             created_files: [],
             deleted_files: [],
         },
@@ -31,10 +31,20 @@ beforeEach(() => {
 describe("subtree checks", () => {
     it("adds merge instructions when PR contains changes in libs/login/", async () => {
         await checkSubtrees();
-        
+
         // First, check that the merge instructions appear correct.
         expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/login/`. It is your responsibility to ensure these changes are merged back into `wordpress-mobile/WordPress-Login-Flow-Android`."));
-        
+
+        // Then, ensure a piece of mock data is present.
+        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
+    })
+
+    it("adds merge instructions when PR contains changes in libs/utils/", async () => {
+        await checkSubtrees();
+
+        // First, check that the merge instructions appear correct.
+        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/utils/`. It is your responsibility to ensure these changes are merged back into `wordpress-mobile/WordPress-Utils-Android`."));
+
         // Then, ensure a piece of mock data is present.
         expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
     })


### PR DESCRIPTION
I've recently updated the `WordPress-Utils-Android` library with the changes from WPAndroid in https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/27. Since we didn't have a peril check to remind developers, the utils library was very outdated. This PR adds this check, so this won't happen again.