### PR TITLE
Use JSON syntax complying to spec in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,11 @@
         "esModuleInterop": true,
         "lib": [
             "es2017",
-            "dom",
+            "dom"
         ],
-        "target": "es2017",
+        "target": "es2017"
     },
     "exclude": [
-        "node_modules",
+        "node_modules"
     ]
 }


### PR DESCRIPTION
My Vim plugin for JSON shows syntax violations.

<img width="588" alt="Screen Shot 2020-05-23 at 10 01 24 pm" src="https://user-images.githubusercontent.com/1218433/82730324-18efea00-9d42-11ea-8c47-9c1514caeda8.png">

[JSON doesn't support trailing commas](https://www.json.org/json-en.html), even though most parsers can deal with it.

<img width="331" alt="Screen Shot 2020-05-23 at 10 04 27 pm" src="https://user-images.githubusercontent.com/1218433/82730330-286f3300-9d42-11ea-8010-45f5bb1f0111.png">


Really, this is only so I don't see red warnings when opening this file 😅