### PR TITLE
Remove Gutenberg exception when checking pod references on iOS

### DIFF
--- a/org/pr/ios-macos.ts
+++ b/org/pr/ios-macos.ts
@@ -18,10 +18,7 @@ export default async () => {
     const podfileContents = await danger.github.utils.fileContents("Podfile");
     const matches = podfileContents.match(/^[^#]*:commit/gm);
     if (matches !== null) {
-        const nonGutenbergMatches = matches.filter(m => !m.includes("gutenberg"));
-        if (nonGutenbergMatches.length > 0) {
-            fail("Podfile: reference to a commit hash");
-        }
+        fail("Podfile: reference to a commit hash");
     }
 
     // If changes were made to the release notes, there must also be changes to the AppStoreStrings file.

--- a/org/pr/ios-macos.ts
+++ b/org/pr/ios-macos.ts
@@ -16,7 +16,7 @@ export default async () => {
 
     // Podfile should not reference commit hashes
     const podfileContents = await danger.github.utils.fileContents("Podfile");
-    const matches = podfileContents.match(/^[^#]*:commit/gm);
+    const matches = podfileContents.match(/^[^#[]*:commit/gm);
     if (matches !== null) {
         fail("Podfile: reference to a commit hash");
     }

--- a/tests/ios-macos.test.ts
+++ b/tests/ios-macos.test.ts
@@ -93,11 +93,9 @@ describe("Podfile should not reference commit hashes checks", () => {
     })
 
     it("fails when finds a commit hash (mobile gutenberg style)", async () => {
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(
-            Promise.resolve(
-                "gutenberg :commit => '84396ab3e79ff7cde5bf59310e1458336fd9b6b6'"
-                )    
-            );
+        let podFile : string = "tag_or_commit = options[:tag] || options[:commit]\n";
+        podFile += "gutenberg :commit => '84396ab3e79ff7cde5bf59310e1458336fd9b6b6'\n";
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(podFile));
 
         await iosMacos();
         
@@ -105,11 +103,9 @@ describe("Podfile should not reference commit hashes checks", () => {
     })
 
     it("does not fail when finds a version (mobile gutenberg style)", async () => {
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(
-            Promise.resolve(
-                "gutenberg :tag => 'v1.39.0'"
-                )    
-            );
+        let podFile : string = "tag_or_commit = options[:tag] || options[:commit]\n";
+        podFile += "gutenberg :tag => 'v1.39.0'\n";
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(podFile));
 
         await iosMacos();
         


### PR DESCRIPTION
This PR removes the exception for Gutenberg when checking that the pods are referenced by version. 

To Test:
- Check that CI is green.