### PR TITLE
Add checks for changes to the release notes in a release branch

### DIFF
--- a/org/pr/release-notes.ts
+++ b/org/pr/release-notes.ts
@@ -21,14 +21,13 @@ export default async () => {
     ];
 
     // Skip if not targeting a release branch
-    if (checkedBranches.filter((branch) => pr.base.ref.startsWith(branch)).length == 0) {
+    if (!checkedBranches.some(branch => pr.base.ref.startsWith(branch))) {
         return;
     }
 
     // Skip for PR labeled as "Releases"
     if (githubLabels.length != 0) {
-        const releases = githubLabels.some(label => label.name.includes("Releases"));
-        if (releases) {
+        if (githubLabels.some(label => label.name.includes("Releases"))) {
             return;
         }
     }

--- a/org/pr/release-notes.ts
+++ b/org/pr/release-notes.ts
@@ -3,6 +3,7 @@
 // This file should typically not be modified after code freeze (i.e. on the release branch).
 
 import {warn, danger} from "danger";
+import { Stream } from "stream";
 
 export default async () => {
     const githubLabels = danger.github.issue.labels;
@@ -14,8 +15,13 @@ export default async () => {
         "RELEASE-NOTES.txt"
     ];
 
-    // Skip if not targeting a release branch 
-    if (!pr.base.ref.startsWith("release/")) {
+    const checkedBranches: string[] = [
+        "release/",
+        "hotfix/"
+    ];
+
+    // Skip if not targeting a release branch
+    if (checkedBranches.filter((branch) => pr.base.ref.startsWith(branch)).length == 0) {
         return;
     }
 

--- a/org/pr/release-notes.ts
+++ b/org/pr/release-notes.ts
@@ -10,7 +10,7 @@ export default async () => {
         "RELEASE-NOTES.txt"
     ];
 
-    // Skip if not on a release branch 
+    // Skip if not targeting a release branch 
     if (!pr.base.ref.startsWith("release/")) {
         return;
     }

--- a/org/pr/release-notes.ts
+++ b/org/pr/release-notes.ts
@@ -1,3 +1,7 @@
+// This Peril rule will warn if the `RELEASE-NOTES.txt` file has been changed in a PR targeting a `release/*` branch.
+//
+// This file should typically not be modified after code freeze (i.e. on the release branch).
+
 import {warn, danger} from "danger";
 
 export default async () => {

--- a/org/pr/release-notes.ts
+++ b/org/pr/release-notes.ts
@@ -27,7 +27,7 @@ export default async () => {
         if (modifiedFiles.some(f => f.includes(releaseNotes))) {
             let messageText: string;
 
-            messageText = "This PR contains changes to RELEASE_NOTES.txt.\n";
+            messageText = "This PR contains changes to \`RELEASE_NOTES.txt\`.\n";
             messageText += "Note that these changes won't affect the final version of the release notes as this version is in code freeze.\n";
             messageText += "Please, get in touch with a release manager if you want to update the final release notes.";
 

--- a/org/pr/release-notes.ts
+++ b/org/pr/release-notes.ts
@@ -1,0 +1,37 @@
+import {warn, danger} from "danger";
+
+export default async () => {
+    const githubLabels = danger.github.issue.labels;
+    const modifiedFiles = danger.git.modified_files;
+    const pr = danger.github.pr;
+
+    // List of release notes files
+    const releaseNotesFiles: string[] = [
+        "RELEASE-NOTES.txt"
+    ];
+
+    // Skip if not on a release branch 
+    if (!pr.base.ref.startsWith("release/")) {
+        return;
+    }
+
+    // Skip for PR labeled as "Releases"
+    if (githubLabels.length != 0) {
+        const releases = githubLabels.some(label => label.name.includes("Releases"));
+        if (releases) {
+            return;
+        }
+    }
+    
+    for (let releaseNotes of releaseNotesFiles) {
+        if (modifiedFiles.some(f => f.includes(releaseNotes))) {
+            let messageText: string;
+
+            messageText = "This PR contains changes to RELEASE_NOTES.txt.\n";
+            messageText += "Note that these changes won't affect the final version of the release notes as this version is in code freeze.\n";
+            messageText += "Please, get in touch with a release manager if you want to update the final release notes.";
+
+            warn(messageText);
+        }
+    }
+};

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -78,7 +78,8 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
-                "Automattic/peril-settings@org/pr/diff-size.ts"
+                "Automattic/peril-settings@org/pr/diff-size.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"
@@ -87,13 +88,15 @@
         "Automattic/simplenote-macos": {
             "pull_request, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/label.ts"
+                "Automattic/peril-settings@org/pr/label.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ]
         },
         "Automattic/simplenote-android": {
             "pull_request, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/android.ts",
-                "Automattic/peril-settings@org/pr/label.ts"
+                "Automattic/peril-settings@org/pr/label.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -12,7 +12,8 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
-                "Automattic/peril-settings@org/pr/diff-size.ts"
+                "Automattic/peril-settings@org/pr/diff-size.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
@@ -28,7 +29,8 @@
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
                 "Automattic/peril-settings@org/pr/diff-size.ts",
-                "Automattic/peril-settings@org/pr/check-subtrees.ts"
+                "Automattic/peril-settings@org/pr/check-subtrees.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
@@ -49,7 +51,8 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/label.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts",
-                "Automattic/peril-settings@org/pr/diff-size.ts"
+                "Automattic/peril-settings@org/pr/diff-size.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts",
@@ -63,7 +66,8 @@
                 "Automattic/peril-settings@org/pr/milestone.ts",
                 "Automattic/peril-settings@org/pr/diff-size.ts",
                 "Automattic/peril-settings@org/pr/check-subtrees.ts",
-                "Automattic/peril-settings@org/pr/check-tracks.ts"
+                "Automattic/peril-settings@org/pr/check-tracks.ts",
+                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"

--- a/tests/release-notes-test.ts
+++ b/tests/release-notes-test.ts
@@ -31,7 +31,7 @@ describe("release notes checks", () => {
     it("warns when RELEASE-NOTES.txt is changed in a PR which targets a release branch", async () => {
         await checkReleaseNotes();
         
-        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to RELEASE_NOTES.txt.\n"));
+        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to \`RELEASE_NOTES.txt\`.\n"));
     })
 
     it("does not warn when RELEASE-NOTES.txt is changed in a PR which targets a release branch if the PR is labeled with Releases", async () => {

--- a/tests/release-notes-test.ts
+++ b/tests/release-notes-test.ts
@@ -66,3 +66,4 @@ describe("release notes checks", () => {
         expect(dm.warn).not.toHaveBeenCalled();
     })
 })
+

--- a/tests/release-notes-test.ts
+++ b/tests/release-notes-test.ts
@@ -1,0 +1,68 @@
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import checkReleaseNotes from "../org/pr/release-notes";
+
+// The mocked data and return values for calls the rule makes.
+beforeEach(() => {
+    dm.warn = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            modified_files: ["RELEASE-NOTES.txt"],
+            created_files: [],
+            deleted_files: []
+        },
+        github: {
+            pr: {
+                base: {
+                    ref: "release/1.0",
+                }
+            },
+            issue: {
+                labels: []
+            },
+        },
+    };
+});
+
+describe("release notes checks", () => {
+    it("warns when RELEASE-NOTES.txt is changed in a PR which targets a release branch", async () => {
+        await checkReleaseNotes();
+        
+        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to RELEASE_NOTES.txt.\n"));
+    })
+
+    it("does not warn when RELEASE-NOTES.txt is changed in a PR which targets a release branch if the PR is labeled with Releases", async () => {
+        dm.danger.github.issue.labels = [
+            {
+                name: 'Releases'
+            }
+        ]
+
+        await checkReleaseNotes();
+        
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
+
+    it("does not warn when RELEASE-NOTES.txt is changed in a PR which doesn't target a release branch", async () => {
+        dm.danger.github.pr.base.ref = "develop";
+
+        await checkReleaseNotes();
+        
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
+
+    it("does not warn when RELEASE-NOTES.txt is not changed", async () => {
+        dm.danger.git.modified_files = [
+                "file1.swift",
+                "file2.php",
+                "file3.kt"
+        ]
+
+        await checkReleaseNotes();
+        
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
+})

--- a/tests/release-notes-test.ts
+++ b/tests/release-notes-test.ts
@@ -34,7 +34,29 @@ describe("release notes checks", () => {
         expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to \`RELEASE_NOTES.txt\`.\n"));
     })
 
+    it("warns when RELEASE-NOTES.txt is changed in a PR which targets a hotfix branch", async () => {
+        dm.danger.github.pr.base.ref = "hotfix/1.0.1";
+
+        await checkReleaseNotes();
+        
+        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes to \`RELEASE_NOTES.txt\`.\n"));
+    })
+
     it("does not warn when RELEASE-NOTES.txt is changed in a PR which targets a release branch if the PR is labeled with Releases", async () => {
+        dm.danger.github.issue.labels = [
+            {
+                name: 'Releases'
+            }
+        ]
+
+        await checkReleaseNotes();
+        
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
+
+    it("does not warn when RELEASE-NOTES.txt is changed in a PR which targets a hotfix branch if the PR is labeled with Releases", async () => {
+        dm.danger.github.pr.base.ref = "hotfix/1.0.1";
+        
         dm.danger.github.issue.labels = [
             {
                 name: 'Releases'


### PR DESCRIPTION
I've noticed that sometimes changes to RELEASE-NOTES.txt are merged into the release branch thinking they will be reflected in the final release notes. Due to how our current flow for translations works, this is not the case and a manual update is required in order to try to update the release notes after the code freeze. 

This PR introduces a new check that prints a warning on PRs that:
-  target the release branch, and 
- contain changes to RELEASE-NOTES.txt. 

To Test:
Testing changes to Peril rules is not easy. Because of this I've added some tests to cover the most common cases. 

 - Make sure CI is green. 
 - Verify that the mocked API responses match the actual GitHub API.