### PR TITLE
Add rule to check that PRs in Android libraries update the version

### DIFF
--- a/org/pr/android-library.ts
+++ b/org/pr/android-library.ts
@@ -1,0 +1,30 @@
+import {fail, danger} from "danger";
+
+// We want each PR towards develop or trunk of our Android libraries to bump
+// the library version. This check makes sure of it.
+export default async () => {
+  const baseBranch = danger.github.pr.base.ref
+  if (baseBranch != "develop" && baseBranch != "trunk") { return }
+
+  // Android projects have more than one build.gradle file, to be able to run
+  // this check on any library, lets's just look into _all_ the build.gradle
+  // files.
+  const modified = danger.git.modified_files
+    .filter((path: string) => path.endsWith('build.gradle'))
+
+  for (let file of modified) {
+    const diff = await danger.git.diffForFile(file)
+
+    // We could be more refined and actually parse the .before and .after
+    // contents to extract the versionName value and do a SemVer check on it to
+    // make sure it's appropriate.
+    //
+    // The '"' is a way to make user the actual versionName definition change,
+    // not a line using versionName.
+    const matchFound = diff.after.includes('versionName "')
+    if (matchFound) { return }
+  }
+
+  // If we're here, no match was found: fail the build.
+  fail(`Please update the library version before merging into \`${baseBranch}\``)
+}

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -38,6 +38,11 @@
                 "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
+        "wordpress-mobile/WordPress-Utils-Android": {
+            "pull_request": [
+                "Automattic/peril-settings@org/pr/android-library.ts"
+            ]
+        },
         "wordpress-mobile/gutenberg-mobile": {
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts",

--- a/tests/android-library.test.ts
+++ b/tests/android-library.test.ts
@@ -1,0 +1,166 @@
+jest.mock("danger", () => jest.fn());
+import danger from "danger";
+const dm = danger as any;
+
+import androidLibrary from "../org/pr/android-library"
+
+beforeEach(() => {
+    dm.fail = jest.fn().mockReturnValue(true);
+})
+
+describe("Development Bintray versions check", () => {
+
+  describe("when the base is not develop or trunk", () => {
+
+    it("doesn't fail even when the version hasn't been changed", async () => {
+      dm.danger = {
+        github: { pr: { base: { ref: "a-branch" } } },
+        git: {
+          modified_files: ["path/to/a/file"],
+          diffForFile: async () => { return { before: '', after: '' } }
+        }
+      }
+
+      await androidLibrary()
+
+      expect(dm.fail).not.toHaveBeenCalled();
+    })
+
+    it("doesn't fail if the version has been changed", async () => {
+      dm.danger = {
+        github: { pr: { base: { ref: "a-branch" } } },
+        git: {
+          modified_files: ["path/to/build.gradle"],
+          diffForFile: async () => {
+            return {
+              before: 'versionName "1.2.3"',
+              after: 'versionName "1.2.4"'
+            }
+          }
+        }
+      }
+
+      await androidLibrary()
+
+      expect(dm.fail).not.toHaveBeenCalled();
+    })
+  })
+
+  describe("when the base is trunk", () => {
+
+    describe("when build.gradle hasn't changed", () => {
+
+      it("emits a failure", async () => {
+        dm.danger = {
+          github: { pr: { base: { ref: "trunk" } } },
+          git: {
+            modified_files: ["path/to/a/file"],
+            diffForFile: async () => { return { before: "", after: "" } }
+          }
+        }
+
+        await androidLibrary()
+
+        expect(dm.fail).toHaveBeenCalledWith("Please update the library version before merging into `trunk`")
+        expect(dm.fail).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe("when build.gradle has changed", () => {
+
+      it("if the version hasn't changed emits a failure", async () => {
+        dm.danger = {
+          github: { pr: { base: { ref: "trunk" } } },
+          git: {
+            modified_files: ["path/to/a/file", "path/to/build.gradle"],
+            diffForFile: async () => { return { before: '', after: '' }
+            }
+          }
+        }
+
+        await androidLibrary()
+
+        expect(dm.fail).toHaveBeenCalledWith("Please update the library version before merging into `trunk`");
+        expect(dm.fail).toHaveBeenCalledTimes(1)
+      })
+
+      it("if the version has changed doesn't emit a failure", async () => {
+        dm.danger = {
+          github: { pr: { base: { ref: "trunk" } } },
+          git: {
+            modified_files: ["path/to/a/file", "path/to/build.gradle"],
+            diffForFile: async () => {
+             return {
+                before: 'versionName "1.2.3"',
+                after: 'versionName "1.2.4"'
+              }
+            }
+          }
+        }
+
+        await androidLibrary()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe("when the base is develop", () => {
+
+    describe("when build.gradle hasn't changed", () => {
+
+      it("emits a failure", async () => {
+        dm.danger = {
+          github: { pr: { base: { ref: "develop" } } },
+          git: {
+            modified_files: ["path/to/a/file"],
+            diffForFile: async () => { return { before: "", after: "" } }
+          }
+        }
+
+        await androidLibrary()
+
+        expect(dm.fail).toHaveBeenCalledWith("Please update the library version before merging into `develop`")
+        expect(dm.fail).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe("when build.gradle has changed", () => {
+
+      it("if the version hasn't changed emits a failure", async () => {
+        dm.danger = {
+          github: { pr: { base: { ref: "develop" } } },
+          git: {
+            modified_files: ["path/to/a/file", "path/to/build.gradle"],
+            diffForFile: async () => { return { before: '', after: '' }
+            }
+          }
+        }
+
+        await androidLibrary()
+
+        expect(dm.fail).toHaveBeenCalledWith("Please update the library version before merging into `develop`");
+        expect(dm.fail).toHaveBeenCalledTimes(1)
+      })
+
+      it("if the version has changed doesn't emit a failure", async () => {
+        dm.danger = {
+          github: { pr: { base: { ref: "develop" } } },
+          git: {
+            modified_files: ["path/to/a/file", "path/to/build.gradle"],
+            diffForFile: async () => {
+             return {
+                before: 'versionName "1.2.3"',
+                after: 'versionName "1.2.4"'
+              }
+            }
+          }
+        }
+
+        await androidLibrary()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds a rule to make sure that every PR towards `develop` or `trunk` in Android libraries bumps the library version.

You can test this using the instructions in https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/49.