### PR TITLE
Remove subtree checks for WPUtils

### DIFF
--- a/org/pr/check-subtrees.ts
+++ b/org/pr/check-subtrees.ts
@@ -15,10 +15,6 @@ export default async () => {
     const subtrees: Subtree[] = [{
         repo: "wordpress-mobile/WordPress-Login-Flow-Android",
         path: "libs/login/"
-    },
-    {
-        repo: "wordpress-mobile/WordPress-Utils-Android",
-        path: "libs/utils/"
     }];
 
     const modifiedFiles = danger.git.modified_files;

--- a/tests/check-subtrees.test.ts
+++ b/tests/check-subtrees.test.ts
@@ -38,14 +38,4 @@ describe("subtree checks", () => {
         // Then, ensure a piece of mock data is present.
         expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
     })
-
-    it("adds merge instructions when PR contains changes in libs/utils/", async () => {
-        await checkSubtrees();
-
-        // First, check that the merge instructions appear correct.
-        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining("This PR contains changes in the subtree `libs/utils/`. It is your responsibility to ensure these changes are merged back into `wordpress-mobile/WordPress-Utils-Android`."));
-
-        // Then, ensure a piece of mock data is present.
-        expect(dm.message).toHaveBeenCalledWith(expect.stringContaining(dm.danger.github.thisPR.repo));
-    })
 })


### PR DESCRIPTION
This PR is a follow up to https://github.com/wordpress-mobile/WordPress-Android/pull/13466 and should be merged after that one. 

It simply removes the checks we do on changes on subtrees for the WPUtils library, because the library is not going to be a subtree anymore. 