### PR TITLE
Update stories repository to reflect renaming

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -107,7 +107,7 @@
                 "Automattic/peril-settings@org/pr/installable-build.ts"
             ]
         },
-        "Automattic/portkey-android": {
+        "Automattic/stories-android": {
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"
             ]


### PR DESCRIPTION
I noticed Peril wasn't commenting with links to installable builds on PRs in https://github.com/Automattic/stories-android/ anymore. It seemed like it had started around the time we renamed the repository from `portkey-android`, and it looks like that's because the reference in `peril-settings` needed to be updated.

I imagine this change is all that's needed to get that working again, but please let me know if I need to do anything else!

For reference, this PR originally added support for installable builds to the stories repo: https://github.com/Automattic/stories-android/pull/179