### PR TITLE
Adds WordPress-FluxC-Android repo to peril settings

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -40,6 +40,11 @@
                 "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
+        "wordpress-mobile/WordPress-FluxC-Android": {
+            "status": [
+                "Automattic/peril-settings@org/pr/optional-tests.ts"
+            ]
+        },
         "wordpress-mobile/WordPress-Utils-Android": {
             "pull_request": [
                 "Automattic/peril-settings@org/pr/android-library.ts"


### PR DESCRIPTION
Since we are currently only interested in marking optional tests as green as implemented in #62, I thought only adding the `status` property would be enough. Admittedly I don't know anything about this json, so I just made an educated guess using the information about the other repos.