### PR TITLE
Fix Android translatable strings check

### DIFF
--- a/org/pr/android.ts
+++ b/org/pr/android.ts
@@ -18,7 +18,7 @@ export default async () => {
         const stringDiffs = await danger.git.diffForFile(file)
 
         for (let stringDiff of stringDiffs.added.replace(/\r/g, "").split(/\n/)) {
-            if (stringDiff.includes("@string/") && (!stringDiff.includes("translatable=false"))) {
+            if (stringDiff.includes("@string/") && (!stringDiff.includes("translatable=\"false\""))) {
                 let markdownText: string;
 
                 markdownText = "This PR adds a translatable entry to \`strings.xml\` which references another string resource: this usually causes issues with translations."

--- a/org/pr/android.ts
+++ b/org/pr/android.ts
@@ -22,8 +22,8 @@ export default async () => {
                 let markdownText: string;
 
                 markdownText = "This PR adds a translatable entry to \`strings.xml\` which references another string resource: this usually causes issues with translations."
-                markdownText += "Please make sure to set the \`translatable=false\` attribute here:"
-                markdownText += "\`` + stringDiff + `\`"
+                markdownText += "Please make sure to set the \`translatable=\"false\"\` attribute here:"
+                markdownText += `\`${stringDiff}\``
 
                 warn(markdownText);
             }

--- a/tests/android-test.ts
+++ b/tests/android-test.ts
@@ -58,7 +58,7 @@ describe("string checks", () => {
         await androidChecks();
         
         // Check that the no message is shown.
-        expect(dm.warn).not.toHaveBeenCalledWith();
+        expect(dm.warn).not.toHaveBeenCalled();
     })
 
     it("doesn't warn when strings resources are added to strings.xml", async () => {
@@ -76,7 +76,7 @@ describe("string checks", () => {
         await androidChecks();
         
         // Check that the no message is shown.
-        expect(dm.warn).not.toHaveBeenCalledWith();
+        expect(dm.warn).not.toHaveBeenCalled();
     })
 
     it("doesn't warn when there are no changes in strings.xml", async () => {
@@ -93,7 +93,7 @@ describe("string checks", () => {
         await androidChecks();
         
         // Check that the no message is shown.
-        expect(dm.warn).not.toHaveBeenCalledWith();
+        expect(dm.warn).not.toHaveBeenCalled();
     })
 
     it("warns when there are changes in metadata/release-notes.txt but not in metadata/PlayStoreStrings.po", async () => {
@@ -127,7 +127,7 @@ describe("string checks", () => {
         await androidChecks();
         
         // Check that the instructions appear correct.
-        expect(dm.warn).not.toHaveBeenCalledWith();
+        expect(dm.warn).not.toHaveBeenCalled();
     })
 
     it("doesn't warn when there are changes in /release-notes.txt", async () => {
@@ -144,7 +144,7 @@ describe("string checks", () => {
         await androidChecks();
         
         // Check that the instructions appear correct.
-        expect(dm.warn).not.toHaveBeenCalledWith();
+        expect(dm.warn).not.toHaveBeenCalled();
     })
 
 })

--- a/tests/android-test.ts
+++ b/tests/android-test.ts
@@ -36,7 +36,11 @@ describe("string checks", () => {
         await androidChecks();
         
         // Check that the instructions appear correct.
-        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR adds a translatable entry to \`strings.xml\` which references another string resource: this usually causes issues with translations."));
+        let expectedText: string;
+        expectedText = "This PR adds a translatable entry to \`strings.xml\` which references another string resource: this usually causes issues with translations."
+        expectedText += "Please make sure to set the \`translatable=\"false\"\` attribute here:"
+        expectedText += "\`+++ <string name=\"login_prologue_screen_title\">@string/app_name</string>\`"
+        expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining(expectedText));
     })
 
     it("doesn't warn when an entry which references another string resources is added with the translatable=false attribute", async () => {


### PR DESCRIPTION
This PR fixes two bugs with the Android translatable strings check: 
- It fixes string interpolation in the warning message.
- It fixes the string pattern that the check uses (and the related tests). 

**To Test:**
Changes to Peril rules can't be easily tested, so: 
- Check that the code changes look good. 
- Check that CI is green.