### PR TITLE
Add warning on soon-closing milestones

### DIFF
--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -30,5 +30,24 @@ export default async () => {
     // Warn if the PR doesn't have a milestone
     if (currentPR.data.milestone == null) {
         warn("PR is not assigned to a milestone.");
+        return;
+    }
+
+    // Warn if the milestone is closing in less than 4 days
+    const warningDays = 4;
+    const warningThreshold = warningDays * 1000 * 3600 * 24; // Convert days to milliseconds
+    if (currentPR.data.milestone.due_on != null) {
+        const today = new Date();
+        let dueDate : Date;
+        dueDate = new Date();
+        dueDate.setTime(Date.parse(currentPR.data.milestone.due_on));
+        
+        if ((dueDate.getTime() - today.getTime()) <= warningThreshold) {
+            let messageText : string;
+
+            messageText = `This PR is assigned to a milestone which is closing in less than ${warningDays} days\n`;
+            messageText += `Please, make sure to get it merged by then or assign it to a later expiring milestone`;
+            warn(messageText)
+        }
     }
 };

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -117,4 +117,32 @@ describe("PR milestone checks", () => {
 
         expect(dm.warn).not.toHaveBeenCalled();
     })
+
+    for(let i = 0; i <= 4; i++) {
+        it("does warn when the milestone is present and closing in 4 days or less", async () => {
+            var closeDate = new Date();
+            closeDate.setDate(closeDate.getDate() + i);
+
+            const mockData = { data: { draft: false, milestone: { number: 1, due_on: closeDate.toISOString() } } };
+            dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
+
+            await milestone();
+
+            expect(dm.warn).toHaveBeenCalledWith(expect.stringContaining("This PR is assigned to a milestone which is closing in less than 4 days"));
+        })
+    }
+
+    for(let i = 5; i <= 14; i++) {
+        it("does not warn when the milestone is present and closing in 5 days or more", async () => {
+            var closeDate = new Date();
+            closeDate.setDate(closeDate.getDate() + i);
+            
+            const mockData = { data: { draft: false, milestone: { number: 1, due_on: closeDate.toISOString() } } };
+            dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
+
+            await milestone();
+
+            expect(dm.warn).not.toHaveBeenCalled();
+        })
+    }
 })


### PR DESCRIPTION
This PR adds a new check on milestones which warns when a milestone is assigned _or_ the PR is modified at a time close to the milestone's due date. 
The initial idea was to post the warning only when a milestone is assigned, but there's no way to get the previous state on Peril, so we can't know the action which triggered Peril.
Anyway, I think that having the warning published also on PRs that are worked on the last days of the cycle has a value. 

There's no easy way to test these changes, so I added some tests based on the [GitHub API documentation](https://docs.github.com/en/rest/reference/issues).