### PR TITLE
Avoid warning about soon to close milestones on merged PRs

### DIFF
--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -36,7 +36,7 @@ export default async () => {
     // Warn if the milestone is closing in less than 4 days
     const warningDays = 4;
     const warningThreshold = warningDays * 1000 * 3600 * 24; // Convert days to milliseconds
-    if (currentPR.data.milestone.due_on != null) {
+    if ((currentPR.data.state != "closed") && (currentPR.data.milestone.due_on != null)) {
         const today = new Date();
         let dueDate : Date;
         dueDate = new Date();

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -145,4 +145,16 @@ describe("PR milestone checks", () => {
             expect(dm.warn).not.toHaveBeenCalled();
         })
     }
+
+    it("does not warn the milestone is closing in 4 days or less and PR is merged", async () => {
+        var closeDate = new Date();
+        closeDate.setDate(closeDate.getDate() + 4);
+
+        const mockData = { data: { draft: false, milestone: { number: 1, due_on: closeDate.toISOString() }, state: "closed" } };
+        dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));
+
+        await milestone();
+
+        expect(dm.warn).not.toHaveBeenCalled();
+    })
 })

--- a/tests/pr-milestone.test.ts
+++ b/tests/pr-milestone.test.ts
@@ -146,9 +146,9 @@ describe("PR milestone checks", () => {
         })
     }
 
-    it("does not warn the milestone is closing in 4 days or less and PR is merged", async () => {
+    it("does not warn when the milestone is closing in 4 days or less, but PR is merged", async () => {
         var closeDate = new Date();
-        closeDate.setDate(closeDate.getDate() + 4);
+        closeDate.setDate(closeDate.getDate() + 2);
 
         const mockData = { data: { draft: false, milestone: { number: 1, due_on: closeDate.toISOString() }, state: "closed" } };
         dm.danger.github.api.pulls.get.mockReturnValueOnce(Promise.resolve(mockData));


### PR DESCRIPTION
This PR fixes an issue with the `milestone` rule where the warning about having set a milestone which is close to its due date is triggered also on merges. 

Looking at [GitHub documentation](https://docs.github.com/en/rest/reference/pulls), the state of a PR is set to `closed` when a PR is closed or merged, so checking for `state == "merged"` should cover both cases. 