### PR TITLE
Update milestone check after "Part of a WIP Feature" label change

### DIFF
--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -22,7 +22,8 @@ export default async () => {
 
         // Skip for PRs for wip features unless the PR is against "develop" or "release/x.x" branches
         const wipFeature = githubLabels.some(label => label.name.includes("Part of a WIP Feature"));
-        if (!targetsDevelop && !targetsRelease && wipFeature) {
+        const donotmergeFeature = githubLabels.some(label => label.name.includes("status: do not merge"));
+        if (!targetsDevelop && !targetsRelease && (wipFeature || donotmergeFeature)) {
             return;
         }
     }

--- a/org/pr/milestone.ts
+++ b/org/pr/milestone.ts
@@ -22,7 +22,7 @@ export default async () => {
 
         // Skip for PRs for wip features unless the PR is against "develop" or "release/x.x" branches
         const wipFeature = githubLabels.some(label => label.name.includes("Part of a WIP Feature"));
-        const donotmergeFeature = githubLabels.some(label => label.name.includes("status: do not merge"));
+        const donotmergeFeature = githubLabels.some(label => label.name.includes("status: feature-flagged"));
         if (!targetsDevelop && !targetsRelease && (wipFeature || donotmergeFeature)) {
             return;
         }


### PR DESCRIPTION
The `Part of a WIP Feature` label was changed to `status: do not merge` in the `woocommerce-android` and `woocommerce-ios` repos.

Since the milestone check Peril rule is used for other repos which may still have the `Part of a WIP Feature`, I tried making it so the update will still work if either label is used. I am actually not sure if I did it right or if I should simply have copied the entire block and change out the constant and label name. Does that make sense?

<sup>(internal reference: paaHJt-244-p2)</sup>