### PR TITLE
Update tracks check after "Tracks" label change

### DIFF
--- a/org/pr/check-tracks.ts
+++ b/org/pr/check-tracks.ts
@@ -68,7 +68,7 @@ export default async () => {
         // Put it all together! 
         messageText = `This PR contains changes to Tracks-related logic. Please ensure the following are completed:\n`;
         messageText += `**PR Author**\n`;
-        messageText += `- The PR must be assigned the **Tracks** label\n`;
+        messageText += `- The PR must be assigned the label **Tracks** or **category: analytics**, depending on which label is avail in the repo you are using.\n`;
         messageText += `**PR Reviewer**\n`;
         messageText += `- The tracks events must be validated in the Tracks system.\n`;
         messageText += `- Verify the internal tracks spreadsheet has also been updated.`;


### PR DESCRIPTION
The `Tracks` label was changed to `category: analytics` in the `woocommerce-android` and `woocommerce-ios` repos.

Since the Peril rule is used for other repos as well, I updated the comment to ask for people to assign the proper label depending on what repo they are using. I couldn't figure out if there are any other implications for the `Tracks` label but I did notice that there were very few PRs using that label at all in the woocommerce repos before the label was updated.

<sup>(internal reference: paaHJt-244-p2)</sup>