### PR TITLE
Fix installable build comments on custom statuses

### DIFF
--- a/tests/installable-build-test.ts
+++ b/tests/installable-build-test.ts
@@ -105,7 +105,7 @@ describe("installable build handling", () => {
         expectComment(webhook, `You can trigger an installable build for these changes by visiting CircleCI [here](${webhook.target_url}).`)
     })
 
-    it("Posts a download comment with the content of comment.json", async () => {
+    it("Posts a download comment with the content of comment.json when the standard context is used", async () => {
       mockedArtifacts = [{
         path: 'comment.json',
         url: 'https://circleci.com/comment.json'
@@ -117,6 +117,31 @@ describe("installable build handling", () => {
       const webhook: any = {
         state: "success",
         context: "ci/circleci: Installable Build",
+        description: "Building",
+        target_url: "https://circleci.com/gh/Owner/Repo/12345?some=query",
+        repository: {
+            name: 'Repo',
+            owner: { login: 'Owner' }
+        },
+        commit: { sha: 'abc' }
+      }
+      await installableBuild(webhook)
+
+      expectComment(webhook, "Mocked download comment.")
+    })
+
+    it("Posts a download comment with the content of comment.json when a custom context containing the app name is used", async () => {
+      mockedArtifacts = [{
+        path: 'comment.json',
+        url: 'https://circleci.com/comment.json'
+      }]
+      mockedCommentJson = {
+        body: 'Mocked download comment.'
+      }
+
+      const webhook: any = {
+        state: "success",
+        context: "ci/circleci: WordPress Installable Build",
         description: "Building",
         target_url: "https://circleci.com/gh/Owner/Repo/12345?some=query",
         repository: {


### PR DESCRIPTION
With the recent changes related to the Jetpack app, Peril stopped to update the `Installable Build` comment on PRs. The root cause of the issue is that the job name used for the WordPress and Jetpack installable builds now contains the app name and, so, the status reported by CircleCI doesn't match the expected one anymore. 
Peril expects a `success` status with `ci/circleci: Installable Build` as the context, but the new context is either `"ci/circleci: WordPress Installable Build"` or `"ci/circleci: Jetpack Installable Build"`.

This PR fixes the issue by using regex for the expected statuses. 


