### PR TITLE
Handle multiple APKs installable for an Installable Build

### DIFF
--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -106,7 +106,7 @@ async function circleCIArtifacts(status) {
 }
 
 async function getDownloadCommentText(status) {
-  const artifacts = await circleCIArtifacts(status)
+  const artifacts: Array<any> = await circleCIArtifacts(status)
 
   const commentJsonArtifact = artifacts.find(artifact => artifact.path.endsWith("comment.json"))
   if (commentJsonArtifact) {
@@ -123,9 +123,12 @@ async function getDownloadCommentText(status) {
     }
   }
 
-  const apkArtifact = artifacts.find(artifact => artifact.path.endsWith(".apk"))
-  if (apkArtifact) {
-    return `You can test the changes on this Pull Request by downloading the APK [here](${apkArtifact.url}).`
+  const apkArtifacts: Array<any> = artifacts.filter(artifact => artifact.path.endsWith(".apk"))
+  if (apkArtifacts.length == 1) {
+    return `You can test the changes on this Pull Request by downloading the APK [here](${apkArtifacts[0].url}).`
+  } else if (apkArtifacts.length > 1) {
+    const links = apkArtifacts.map(artifact => `- [${artifact.path}](${artifact.url})`).join(`\n`)
+    return `You can test the changes on this Pull Request by downloading the APKs:\n${links}.`
   }
   return undefined
 }

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -127,7 +127,7 @@ async function getDownloadCommentText(status) {
   if (apkArtifacts.length == 1) {
     return `You can test the changes on this Pull Request by downloading the APK [here](${apkArtifacts[0].url}).`
   } else if (apkArtifacts.length > 1) {
-    const links = apkArtifacts.map(artifact => `- [${artifact.path}](${artifact.url})`).join(`\n`)
+    const links = apkArtifacts.map(artifact => `- [${artifact.path.split("/").pop()}](${artifact.url})`).join(`\n`)
     return `You can test the changes on this Pull Request by downloading the APKs:\n${links}.`
   }
   return undefined

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -127,8 +127,8 @@ async function getDownloadCommentText(status) {
   if (apkArtifacts.length == 1) {
     return `You can test the changes on this Pull Request by downloading the APK [here](${apkArtifacts[0].url}).`
   } else if (apkArtifacts.length > 1) {
-    const links = apkArtifacts.map(artifact => `- [${artifact.path.split("/").pop()}](${artifact.url})`).join(`\n`)
-    return `You can test the changes on this Pull Request by downloading the APKs:\n${links}.`
+    const links = apkArtifacts.map(artifact => ` - [${artifact.path.split("/").pop()}](${artifact.url})`).join(`\n`)
+    return `You can test the changes on this Pull Request by downloading the APKs:\n${links}`
   }
   return undefined
 }

--- a/tests/installable-build-test.ts
+++ b/tests/installable-build-test.ts
@@ -174,6 +174,6 @@ describe("installable build handling", () => {
       }
       await installableBuild(webhook)
 
-      expectComment(webhook, `You can test the changes on this Pull Request by downloading the APKs:\n- [file1.apk](${mockedArtifacts[0].url})\n- [file2.apk](${mockedArtifacts[1].url}).`)
+      expectComment(webhook, `You can test the changes on this Pull Request by downloading the APKs:\n - [file1.apk](${mockedArtifacts[0].url})\n - [file2.apk](${mockedArtifacts[1].url})`)
     })
 })

--- a/tests/installable-build-test.ts
+++ b/tests/installable-build-test.ts
@@ -154,8 +154,8 @@ describe("installable build handling", () => {
 
     it("Posts a download comment linking to multiple APKs", async () => {
       mockedArtifacts = [{
-        path: 'file1.apk',
-        url: 'https://circleci.com/file1.apk'
+        path: 'Artifacts/file1.apk',
+        url: 'https://circleci.com/artifacts/file1.apk'
       },{
         path: 'file2.apk',
         url: 'https://circleci.com/file2.apk'

--- a/tests/installable-build-test.ts
+++ b/tests/installable-build-test.ts
@@ -151,4 +151,29 @@ describe("installable build handling", () => {
 
       expectComment(webhook, `You can test the changes on this Pull Request by downloading the APK [here](${mockedArtifacts[0].url}).`)
     })
+
+    it("Posts a download comment linking to multiple APKs", async () => {
+      mockedArtifacts = [{
+        path: 'file1.apk',
+        url: 'https://circleci.com/file1.apk'
+      },{
+        path: 'file2.apk',
+        url: 'https://circleci.com/file2.apk'
+      }]
+
+      const webhook: any = {
+        state: "success",
+        context: "ci/circleci: Installable Build",
+        description: "Building",
+        target_url: "https://circleci.com/gh/Owner/Repo/12345?some=query",
+        repository: {
+            name: 'Repo',
+            owner: { login: 'Owner' }
+        },
+        commit: { sha: 'abc' }
+      }
+      await installableBuild(webhook)
+
+      expectComment(webhook, `You can test the changes on this Pull Request by downloading the APKs:\n- [file1.apk](${mockedArtifacts[0].url})\n- [file2.apk](${mockedArtifacts[1].url}).`)
+    })
 })


### PR DESCRIPTION
The link in the Peril comment for the installable WPAndroid build (e.g https://github.com/wordpress-mobile/WordPress-Android/pull/14936#issuecomment-868401819) is actually pointing to the Jetpack app.

We're able to download the apk if we visit the artifacts page anyway, but it's nicer to have Peril provide the link for all installable APKs not just the first one.

\cc @hypest 