### PR TITLE
Update optional tests state for Simplenote-iOS

### DIFF
--- a/org/pr/optional-tests.ts
+++ b/org/pr/optional-tests.ts
@@ -10,7 +10,8 @@ const HOLD_CONTEXTS: string[] = [
     "ci/circleci: Installable Build/Approve Jetpack",
     "ci/circleci: Installable Build/Approve WordPress",
     "ci/circleci: wordpress_ios/Optional Tests",
-    "ci/circleci: fluxc/Optional Tests"
+    "ci/circleci: fluxc/Optional Tests",
+    "ci/circleci: simplenote_ios/Optional Full UI Test"
 ]
 
 async function markStatusAsSuccess(status) {

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -86,7 +86,8 @@
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [
-                "Automattic/peril-settings@org/pr/installable-build.ts"
+                "Automattic/peril-settings@org/pr/installable-build.ts",
+                "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
         "Automattic/simplenote-macos": {

--- a/tests/optional-tests-test.ts
+++ b/tests/optional-tests-test.ts
@@ -58,7 +58,10 @@ const expectComment = (webhook, commentBody) => {
 const testHoldContexts: string[] = [
     "ci/circleci: Optional Tests/Hold",
     "ci/circleci: wordpress_ios/Optional Tests",
-    "ci/circleci: fluxc/Optional Tests"
+    "ci/circleci: fluxc/Optional Tests",
+    "ci/circleci: Installable Build/Approve Jetpack",
+    "ci/circleci: Installable Build/Approve WordPress",
+    "ci/circleci: simplenote_ios/Optional Full UI Test"
 ]
 
 describe("optional test handling", () => {


### PR DESCRIPTION
While working [on a small PR on Simplenote iOS](https://github.com/Automattic/simplenote-ios/pull/1318) I noticed that the status of Optional Tests which are on hold is not green. 

This PR adds the Simplenote iOS Optional Tests to the list of jobs which PR updates to avoid that the status of the PR never goes green. 