### PR TITLE
Update peril-settings to reduce GitHub API calls

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -8,15 +8,16 @@
     "rules": {},
     "repos": {
         "wordpress-mobile/WordPress-iOS": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
+            "pull_request": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts",
+                "Automattic/peril-settings@org/pr/milestone.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts"
-            ],
-            "issues.opened, issues.labeled, issues.unlabeled": [
-                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts",
@@ -24,15 +25,16 @@
             ]
         },
         "wordpress-mobile/WordPress-Android": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
+            "pull_request": [
                 "Automattic/peril-settings@org/pr/android.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts",
+                "Automattic/peril-settings@org/pr/milestone.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/android-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts"
-            ],
-            "issues.opened, issues.labeled, issues.unlabeled": [
-                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts",
@@ -51,10 +53,14 @@
             ]
         },
         "woocommerce/woocommerce-ios": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
+            "pull_request": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts",
+                "Automattic/peril-settings@org/pr/milestone.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts",
                 "Automattic/peril-settings@org/pr/check-tracks.ts"
@@ -65,23 +71,31 @@
             ]
         },
         "woocommerce/woocommerce-android": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
+            "pull_request": [
                 "Automattic/peril-settings@org/pr/android.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts",
+                "Automattic/peril-settings@org/pr/milestone.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/android-diff-size.ts",
-                "Automattic/peril-settings@org/pr/check-tracks.ts",
-                "Automattic/peril-settings@org/pr/release-notes.ts"
+                "Automattic/peril-settings@org/pr/release-notes.ts",
+                "Automattic/peril-settings@org/pr/check-tracks.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts"
             ]
         },
         "Automattic/simplenote-ios": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
+            "pull_request": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts",
+                "Automattic/peril-settings@org/pr/milestone.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
@@ -91,16 +105,24 @@
             ]
         },
         "Automattic/simplenote-macos": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
-                "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
+            "pull_request": [
+                "Automattic/peril-settings@org/pr/ios-macos.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ]
         },
         "Automattic/simplenote-android": {
-            "pull_request, pull_request.labeled, pull_request.unlabeled": [
-                "Automattic/peril-settings@org/pr/android.ts",
-                "Automattic/peril-settings@org/pr/label.ts",
+            "pull_request": [
+                "Automattic/peril-settings@org/pr/android.ts"
+            ],
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [


### PR DESCRIPTION
### Why

While looking at p1629260121056500-slack-C02QANACA I noticed that we ran all our main Danger rules on _every_ action of the `pull_request` event, while some of them only make sense to be run on specific ones.

 - In particular, we run those rules even on actions like `pull_request.closed` while at that stage there's no need to re-run Danger.  
 - We also re-run rules that run checks on certain things that couldn't have been changed by certain events, e.g. we tested the labels even on new commits pushed on the PR without any label change, or re-checked the release notes or the diff size even just when the only thing that triggered the webhook was a label being added, etc.

As a result, we ended up having Danger/Peril failures from time to time, due:
 - Either to glitches in the API that made Danger fail when running some rules on PR closed (see Slack conversation linked above), while there was no point to re-run Danger in those cases in the first place
 - Or us reaching the GitHub API rate-limit, which when it happens makes all the subsequent API calls and all Danger/Peril runs on all pull requests fail for a couple of hours until the limit is cleared. (see p1623162838019800-slack-CEJT26EG1)

### How

By running some rules only for the specific events that makes sense for them, we should reduce the API usage and the risk of GitHub API and Peril erroring.
