### PR TITLE
Fix rule settings for labels

### DIFF
--- a/org/pr/android.ts
+++ b/org/pr/android.ts
@@ -2,11 +2,15 @@ import {warn, danger} from "danger";
 
 export default async () => {
 
-    // If changes were made to the release notes in the metadata folder, there must also be changes to the PlayStoreStrings file.
+    // Store the relevant data
+    // This is a workaround for a weird issue/glitch we have been experiencing
+    // where, sometimes, the data is not accessible later in the flow
     const modifiedFiles = danger.git.modified_files;
     const hasModifiedReleaseNotes = modifiedFiles.some(f => f.endsWith("metadata/release_notes.txt"));
     const hasModifiedPlayStoreStrings = modifiedFiles.some(f => f.includes("metadata/PlayStoreStrings.po"));
+    const git = danger.git;
 
+    // If changes were made to the release notes in the metadata folder, there must also be changes to the PlayStoreStrings file.
     if (hasModifiedReleaseNotes && !hasModifiedPlayStoreStrings) {
         warn("The PlayStoreStrings.po file must be updated any time changes are made to release notes");
     }
@@ -15,7 +19,7 @@ export default async () => {
     const modifiedStrings = modifiedFiles.filter((path: string) => path.endsWith('values/strings.xml'))
 
     for (let file of modifiedStrings) {        
-        const stringDiffs = await danger.git.diffForFile(file)
+        const stringDiffs = await git.diffForFile(file)
 
         for (let stringDiff of stringDiffs.added.replace(/\r/g, "").split(/\n/)) {
             if (stringDiff.includes("@string/") && (!stringDiff.includes("translatable=\"false\""))) {

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -12,8 +12,11 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
@@ -29,7 +32,10 @@
                 "Automattic/peril-settings@org/pr/android.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
+                "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
@@ -57,8 +63,11 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
@@ -75,8 +84,11 @@
                 "Automattic/peril-settings@org/pr/android.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/android-diff-size.ts",
@@ -92,8 +104,11 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
@@ -108,8 +123,11 @@
             "pull_request": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/release-notes.ts"
@@ -119,8 +137,11 @@
             "pull_request": [
                 "Automattic/peril-settings@org/pr/android.ts"
             ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled, issues.opened, issues.labeled, issues.unlabeled": [
+            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
+            ],
+            "issues.opened, issues.labeled, issues.unlabeled": [
+                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize": [
                 "Automattic/peril-settings@org/pr/release-notes.ts"

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -18,7 +18,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
@@ -38,7 +38,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/android-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
@@ -69,7 +69,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts",
                 "Automattic/peril-settings@org/pr/check-tracks.ts"
@@ -90,7 +90,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/android-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts",
                 "Automattic/peril-settings@org/pr/check-tracks.ts"
@@ -110,7 +110,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
@@ -129,7 +129,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ]
         },
@@ -143,7 +143,7 @@
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
             ],
-            "pull_request.opened, pull_request.synchronize": [
+            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [


### PR DESCRIPTION
The recent PR https://github.com/Automattic/peril-settings/pull/84 accidentally merged the settings for `issue/labels.ts` and `pr/labels.ts` into a single set of events all related to Pull Requests only, resulting in the `Please add a type label to this issue. e.g. '[Type] Enhancement'` message from the `issue/labels.ts` rule now appearing in all `Releases` PRs (example [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15228#issuecomment-903180621))

We thus missed the fact that there are actually two different rules for labels, one for issue and one for PR, and they still need to be kept on separate triggers.

---

In addition, I also:
 - added the `labeled`/`unlabeled` event triggers on the diff and release-notes rules as they both depends on which labels are set (and make exceptions for e.g. when the `Releases` label is set).
 - Applied the same workaround as #85 for `android.ts` – because I saw it fail on `danger.git.diffForFile(…)` in https://github.com/wordpress-mobile/WordPress-Android/pull/15233#issuecomment-903597527