### PR TITLE
Temporarily remove label checks on woo issues

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -66,9 +66,6 @@
             "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
             ],
-            "issues.opened, issues.labeled, issues.unlabeled": [
-                "Automattic/peril-settings@org/issue/label.ts"
-            ],
             "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/ios-diff-size.ts",
                 "Automattic/peril-settings@org/pr/release-notes.ts",
@@ -86,9 +83,6 @@
             ],
             "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
-            ],
-            "issues.opened, issues.labeled, issues.unlabeled": [
-                "Automattic/peril-settings@org/issue/label.ts"
             ],
             "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/android-diff-size.ts",


### PR DESCRIPTION
In https://github.com/Automattic/peril-settings/pull/84 we updated the rules for running the Peril checks in order to optimise the API calls to GitHub and we took the chance to reorganize and realign which rules we run on eacg repository on each event.

While doing that, we mistakenly enabled the "labels on issues" check on WooCommerce, but the current rule is not compatible with the new label format used in those repositories.

This PR temporarily disable the rule in order to avoid confusion, until we fix it and make it compatible with WooCommerce label format.