### PR TITLE
Fix WPiOS optional tests

### DIFF
--- a/org/pr/optional-tests.ts
+++ b/org/pr/optional-tests.ts
@@ -7,8 +7,6 @@ const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
 // This is a list of the CircleCI statuses to process
 const HOLD_CONTEXTS: string[] = [
     "ci/circleci: Optional Tests/Hold",
-    "ci/circleci: Installable Build/Approve Jetpack",
-    "ci/circleci: Installable Build/Approve WordPress",
     "ci/circleci: wordpress_ios/Optional Tests",
     "ci/circleci: fluxc/Optional Tests",
     "ci/circleci: simplenote_ios/Optional Full UI Test"

--- a/tests/optional-tests-test.ts
+++ b/tests/optional-tests-test.ts
@@ -59,8 +59,6 @@ const testHoldContexts: string[] = [
     "ci/circleci: Optional Tests/Hold",
     "ci/circleci: wordpress_ios/Optional Tests",
     "ci/circleci: fluxc/Optional Tests",
-    "ci/circleci: Installable Build/Approve Jetpack",
-    "ci/circleci: Installable Build/Approve WordPress",
     "ci/circleci: simplenote_ios/Optional Full UI Test"
 ]
 


### PR DESCRIPTION
This PR revert "Add Jetpack-specific hold contexts for tests" which should fix a weird behaviour on Optional Tests for WPiOS.