### PR TITLE
Update the Installable Build job status for Jetpack

### DIFF
--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -8,9 +8,9 @@ const CIRCLECI_TOKEN: string = process.env['CIRCLECI_TOKEN']
 const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
 
 // This is a list of the CircleCI statuses to process
-const HOLD_CONTEXTS: string[] = ["ci/circleci: Installable Build/Hold", "ci/circleci: Installable Build/Approve WordPress"]
+const HOLD_CONTEXTS_COMMENT: string[] = ["ci/circleci: Installable Build/Hold", "ci/circleci: Installable Build/Approve WordPress"]
 // In some cases, we want to update the status of the job, but we don't want to post a CFA comment.
-const HOLD_CONTEXTS_NO_COMMENT: string[] = ["ci/circleci: Installable Build/Approve Jetpack"]
+const HOLD_CONTEXTS: string[] = ["ci/circleci: Installable Build/Approve Jetpack"]
 // The following statuses are described with regex in order to be able to handle special cases where the app name is added to the state, 
 // e.g. "ci/circleci: Jetpack Installable Build"
 const INSTALLABLE_BUILD_CONTEXTS: string[] = ["ci\/circleci:.*Installable Build$", "ci\/circleci:.*Test Android on Device$"] 
@@ -138,9 +138,9 @@ async function getDownloadCommentText(status) {
 }
 
 export default async (status: Status) => {
-    if (status.state == "pending" && HOLD_CONTEXTS.concat(HOLD_CONTEXTS_NO_COMMENT).includes(status.context)) {
+    if (status.state == "pending" && HOLD_CONTEXTS_COMMENT.concat(HOLD_CONTEXTS).includes(status.context)) {
       await markStatusAsSuccess(status)
-      if (HOLD_CONTEXTS.includes(status.context)) {
+      if (HOLD_CONTEXTS_COMMENT.includes(status.context)) {
         await createOrUpdateComment(status, `You can trigger an installable build for these changes by visiting CircleCI [here](${status.target_url}).`)
       }
     } else if (status.state ==  "success" && INSTALLABLE_BUILD_CONTEXTS.filter(s => status.context.match(s)).length > 0) {

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -9,6 +9,8 @@ const PERIL_BOT_USER_ID: number = parseInt(process.env['PERIL_BOT_USER_ID'], 10)
 
 // This is a list of the CircleCI statuses to process
 const HOLD_CONTEXTS: string[] = ["ci/circleci: Installable Build/Hold", "ci/circleci: Installable Build/Approve WordPress"]
+// In some cases, we want to update the status of the job, but we don't want to post a CFA comment.
+const HOLD_CONTEXTS_NO_COMMENT: string[] = ["ci/circleci: Installable Build/Approve Jetpack"]
 // The following statuses are described with regex in order to be able to handle special cases where the app name is added to the state, 
 // e.g. "ci/circleci: Jetpack Installable Build"
 const INSTALLABLE_BUILD_CONTEXTS: string[] = ["ci\/circleci:.*Installable Build$", "ci\/circleci:.*Test Android on Device$"] 
@@ -136,7 +138,7 @@ async function getDownloadCommentText(status) {
 }
 
 export default async (status: Status) => {
-    if (status.state == "pending" && HOLD_CONTEXTS.includes(status.context)) {
+    if (status.state == "pending" && HOLD_CONTEXTS.concat(HOLD_CONTEXTS_NO_COMMENT).includes(status.context)) {
       await markStatusAsSuccess(status)
       await createOrUpdateComment(status, `You can trigger an installable build for these changes by visiting CircleCI [here](${status.target_url}).`)
     } else if (status.state ==  "success" && INSTALLABLE_BUILD_CONTEXTS.filter(s => status.context.match(s)).length > 0) {

--- a/org/pr/installable-build.ts
+++ b/org/pr/installable-build.ts
@@ -140,7 +140,9 @@ async function getDownloadCommentText(status) {
 export default async (status: Status) => {
     if (status.state == "pending" && HOLD_CONTEXTS.concat(HOLD_CONTEXTS_NO_COMMENT).includes(status.context)) {
       await markStatusAsSuccess(status)
-      await createOrUpdateComment(status, `You can trigger an installable build for these changes by visiting CircleCI [here](${status.target_url}).`)
+      if (HOLD_CONTEXTS.includes(status.context)) {
+        await createOrUpdateComment(status, `You can trigger an installable build for these changes by visiting CircleCI [here](${status.target_url}).`)
+      }
     } else if (status.state ==  "success" && INSTALLABLE_BUILD_CONTEXTS.filter(s => status.context.match(s)).length > 0) {
       const commentBody = await getDownloadCommentText(status)
       if (commentBody === undefined) {

--- a/tests/installable-build-test.ts
+++ b/tests/installable-build-test.ts
@@ -107,7 +107,7 @@ describe("installable build handling", () => {
 
     // This is a special case to handle the Jetpack application: since it shares the repository with WordPress,
     // we don't want a "trigger" comment to be generated, but we still want the status of the job to be green when on hold
-    it("updates the status to be 'success' when it is the right context, and comments", async () => {
+    it("updates the status to be 'success' when it is the right context, but doesn't comment", async () => {
       const webhook: any = {
           state: "pending",
           context: "ci/circleci: Installable Build/Approve Jetpack",
@@ -129,6 +129,8 @@ describe("installable build handling", () => {
           description: webhook.description,
           target_url: webhook.target_url,
       })
+
+      expect(dm.danger.github.api.issues.createComment).not.toHaveBeenCalled();
   })
 
     it("Posts a download comment with the content of comment.json when the standard context is used", async () => {

--- a/tests/installable-build-test.ts
+++ b/tests/installable-build-test.ts
@@ -105,6 +105,32 @@ describe("installable build handling", () => {
         expectComment(webhook, `You can trigger an installable build for these changes by visiting CircleCI [here](${webhook.target_url}).`)
     })
 
+    // This is a special case to handle the Jetpack application: since it shares the repository with WordPress,
+    // we don't want a "trigger" comment to be generated, but we still want the status of the job to be green when on hold
+    it("updates the status to be 'success' when it is the right context, and comments", async () => {
+      const webhook: any = {
+          state: "pending",
+          context: "ci/circleci: Installable Build/Approve Jetpack",
+          description: "Holding build",
+          target_url: "https://circleci.com/workflow-run/abcdefg",
+          repository: {
+              name: 'Repo',
+              owner: { login: 'Owner' }
+          },
+          commit: { sha: 'abc' }
+      }
+      await installableBuild(webhook)
+
+      expect(dm.danger.github.api.repos.createStatus).toBeCalledWith({
+          owner: webhook.repository.owner.login,
+          repo: webhook.repository.name,
+          state: "success",
+          context: webhook.context,
+          description: webhook.description,
+          target_url: webhook.target_url,
+      })
+  })
+
     it("Posts a download comment with the content of comment.json when the standard context is used", async () => {
       mockedArtifacts = [{
         path: 'comment.json',


### PR DESCRIPTION
After https://github.com/Automattic/peril-settings/pull/89 got merged, I've started noticing that the status of the `Installable Build` job for the Jetpack application doesn't get updated from `pending (orange)` to `ready (green)`. 

The reason is that [this commit](https://github.com/Automattic/peril-settings/commit/1ed4cc4df9518037fc2287fd0278c15aace56c9d) removed it from the list of the handled states. 
My understanding, from the commit title, is that the goal was to avoid that Peril commented on the PR with the prompt to run the installable build for Jetpack.
I think we still want the state of the job to be green, because, otherwise, the PR remains in a pending state and, while it's still possible to merge the changes because the job is not required, this behaviour can create confusion. 
My take is that the bug that https://github.com/Automattic/peril-settings/pull/89 fixed was actually hiding this problem. 

This PR should fix this problem. There are probably better ways to do this, and the test cases are not complete and strong, but since @jkmassel mentioned that with the migration to Buildkite this function will be integrated in the CI and won't be required anymore in Peril, I opted for a quick, minimal and easy solution.
 