### PR TITLE
Adds 'ci/circleci: Optional UI Tests/Hold' to optional-tests

### DIFF
--- a/org/pr/optional-tests.ts
+++ b/org/pr/optional-tests.ts
@@ -9,7 +9,8 @@ const HOLD_CONTEXTS: string[] = [
     "ci/circleci: Optional Tests/Hold",
     "ci/circleci: wordpress_ios/Optional Tests",
     "ci/circleci: fluxc/Optional Tests",
-    "ci/circleci: simplenote_ios/Optional Full UI Test"
+    "ci/circleci: simplenote_ios/Optional Full UI Test",
+    "ci/circleci: Optional UI Tests/Hold"
 ]
 
 async function markStatusAsSuccess(status) {

--- a/tests/optional-tests-test.ts
+++ b/tests/optional-tests-test.ts
@@ -59,7 +59,8 @@ const testHoldContexts: string[] = [
     "ci/circleci: Optional Tests/Hold",
     "ci/circleci: wordpress_ios/Optional Tests",
     "ci/circleci: fluxc/Optional Tests",
-    "ci/circleci: simplenote_ios/Optional Full UI Test"
+    "ci/circleci: simplenote_ios/Optional Full UI Test",
+    "ci/circleci: Optional UI Tests/Hold"
 ]
 
 describe("optional test handling", () => {


### PR DESCRIPTION
This should fix the `Pending` "ci/circleci: Optional UI Tests/Hold" for WCAndroid.