### PR TITLE
Adds optional-tests to WCAndroid repo

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -96,7 +96,8 @@
                 "Automattic/peril-settings@org/pr/check-tracks.ts"
             ],
             "status": [
-                "Automattic/peril-settings@org/pr/installable-build.ts"
+                "Automattic/peril-settings@org/pr/installable-build.ts",
+                "Automattic/peril-settings@org/pr/optional-tests.ts"
             ]
         },
         "Automattic/simplenote-ios": {


### PR DESCRIPTION
In #96, I missed that `optional-tests` wasn't added to WCAndroid repo, so unfortunately that change alone wasn't enough.