### PR TITLE
Decrease Woo PR Milestone Warning days

### DIFF
--- a/org/pr/milestone-woo.ts
+++ b/org/pr/milestone-woo.ts
@@ -1,0 +1,53 @@
+import {warn, danger} from "danger";
+
+export default async () => {
+    // Create consts for everything we need from `danger` object as soon as possible
+    // so it's not dropped during await operation
+    const githubLabels = danger.github.issue.labels;
+    const targetsDevelop = danger.github.pr.base.ref == "develop";
+    const targetsRelease = danger.github.pr.base.ref.startsWith("release/");
+    const currentPR = await danger.github.api.pulls.get(danger.github.thisPR);
+
+    // Skip for draft PRs
+    if (currentPR.data.draft) {
+        return;
+    }
+
+    if (githubLabels.length != 0) {
+        // Skip for PRs with "Releases" label
+        const releases = githubLabels.some(label => label.name.includes("Releases"));
+        if (releases) {
+            return;
+        }
+
+        // Skip for PRs for wip features unless the PR is against "develop" or "release/x.x" branches
+        const wipFeature = githubLabels.some(label => label.name.includes("Part of a WIP Feature"));
+        if (!targetsDevelop && !targetsRelease && wipFeature) {
+            return;
+        }
+    }
+
+    // Warn if the PR doesn't have a milestone
+    if (currentPR.data.milestone == null) {
+        warn("PR is not assigned to a milestone.");
+        return;
+    }
+
+    // Warn if the milestone is closing in less than 4 days
+    const warningDays = 2;
+    const warningThreshold = warningDays * 1000 * 3600 * 24; // Convert days to milliseconds
+    if ((currentPR.data.state != "closed") && (currentPR.data.milestone.due_on != null)) {
+        const today = new Date();
+        let dueDate : Date;
+        dueDate = new Date();
+        dueDate.setTime(Date.parse(currentPR.data.milestone.due_on));
+
+        if ((dueDate.getTime() - today.getTime()) <= warningThreshold) {
+            let messageText : string;
+
+            messageText = `This PR is assigned to a milestone which is closing in less than ${warningDays} days\n`;
+            messageText += `Please, make sure to get it merged by then or assign it to a later expiring milestone`;
+            warn(messageText)
+        }
+    }
+};

--- a/org/pr/milestone-woo.ts
+++ b/org/pr/milestone-woo.ts
@@ -33,7 +33,7 @@ export default async () => {
         return;
     }
 
-    // Warn if the milestone is closing in less than 4 days
+    // Warn if the milestone is closing in less than 2 days
     const warningDays = 2;
     const warningThreshold = warningDays * 1000 * 3600 * 24; // Convert days to milliseconds
     if ((currentPR.data.state != "closed") && (currentPR.data.milestone.due_on != null)) {

--- a/peril-settings.json
+++ b/peril-settings.json
@@ -61,7 +61,7 @@
         "woocommerce/woocommerce-ios": {
             "pull_request": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts"
+                "Automattic/peril-settings@org/pr/milestone-woo.ts"
             ],
             "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"
@@ -82,7 +82,7 @@
         "woocommerce/woocommerce-android": {
             "pull_request": [
                 "Automattic/peril-settings@org/pr/android.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts"
+                "Automattic/peril-settings@org/pr/milestone-woo.ts"
             ],
             "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
                 "Automattic/peril-settings@org/pr/label.ts"


### PR DESCRIPTION
# Description
Since we recently moved to 1-week release cycles and milestones matching these releases, we always get those warnings if we assign the PR to the next milestone (which happens often) because it is always closing in less than 4 days. That adds too much noise and loses the original intent of those warnings. Because of that, we decrease the warning days to two with this PR.

> Internal Ref: pdnsEh-B2-p2

# Changes
- Create a new milestone file for woo with 2 warning days
- Point to that file in the peril settings json for woo ios and android