### PR TITLE
Block WPAndroid PRs tagged as 'Not Ready for Merge'

### DIFF
--- a/org/pr/label.ts
+++ b/org/pr/label.ts
@@ -8,8 +8,13 @@ export default async () => {
         warn("PR is missing at least one label.");
     }
 
+    function is_do_not_merge_label(label) {
+        var lc_label = label.name.toLowerCase();
+        return lc_label.includes("do not merge") || lc_label.includes("not ready for merge");
+    }
+
     // A PR shouldn't be merged with the 'DO NOT MERGE' label
-    const doNotMergeLabel = githubLabels.find(label => label.name.toLowerCase().includes("do not merge"));
+    const doNotMergeLabel = githubLabels.find(is_do_not_merge_label);
     if (doNotMergeLabel) {
         fail(`This PR is tagged with '${doNotMergeLabel.name}' label.`);
     }

--- a/org/pr/label.ts
+++ b/org/pr/label.ts
@@ -9,7 +9,7 @@ export default async () => {
     }
 
     function is_do_not_merge_label(label) {
-        var lc_label = label.name.toLowerCase();
+        const lc_label = label.name.toLowerCase();
         return lc_label.includes("do not merge") || lc_label.includes("not ready for merge");
     }
 

--- a/tests/pr-label.test.ts
+++ b/tests/pr-label.test.ts
@@ -49,6 +49,18 @@ describe("PR label checks", () => {
         expect(dm.fail).toHaveBeenCalledWith("This PR is tagged with 'status: do not merge' label.");
     })
 
+    it("fails if '[Status] Not Ready for Merge' label is present (WPAndroid repo)", async () => {
+        dm.danger.github.issue.labels = [
+            {
+                name: '[Status] Not Ready for Merge'
+            }
+        ]
+
+        await label();
+
+        expect(dm.fail).toHaveBeenCalledWith("This PR is tagged with '[Status] Not Ready for Merge' label.");
+    })
+
     it("does not fail if there is no do-not-merge label", async () => {
         dm.danger.github.issue.labels = [
             {


### PR DESCRIPTION
WPAndroid repos use a different name for that kind of label, with 'not ready for merge' rather than 'do not merge' wording, so we have to take that into account too.

---

This is to prevent the case of accidental merge of https://github.com/wordpress-mobile/WordPress-Android/pull/17581#issuecomment-1332383754 I did earlier today — and had to revert later in https://github.com/wordpress-mobile/WordPress-Android/pull/17584 — to ever happen again.