### PR TITLE
Support nested dependencies from `Podfile.lock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 
 These are the settings for running [Peril](https://github.com/danger/peril) on repositories in `Automattic`, `simplenote` and `wordpress-mobile`.
 
-### Installing
+## Development Environment
 
-After cloning the repo, run `yarn install`.
+### Using Docker
 
-### Running the tests
+You can use Docker to work and test this project in the appropriate container.
 
-Tests can be run with `yarn test`.
+```
+docker run -it --rm --init --volume "${PWD}":/workdir --workdir /workdir node:10 /bin/sh -e -c $'yarn install --frozen-lockfile; yarn jest'
+```
+
+### Without Docker
+
+ - Clone the repo.
+ - Ensure you have `node` and `yarn` installed on your machine.
+ - Run `yarn install`.
+ - Run the tests using `yarn jest`.

--- a/org/pr/ios-macos.ts
+++ b/org/pr/ios-macos.ts
@@ -35,8 +35,7 @@ export default async () => {
     // DEPENDENCIES:
     //     - Kanvas(from `https://github.com/tumblr/Kanvas-iOS.git`, branch `main`)
     //     - WordPress - Editor - iOS(~> 1.19.8)
-    //     - WordPressUI(from `https://github.com/wordpress-mobile/WordPressUI-iOS`, commit `5ab5fd3dc8f50a27181cf14e101abe3599398
-// cad`)
+    //     - WordPressUI(from `https://github.com/wordpress-mobile/WordPressUI-iOS`, commit `5ab5fd3dc8f50a27181cf14e101abe3599398cad`)
     const podfileLockContents = await danger.github.utils.fileContents("Podfile.lock");
     const podfileLockYAML = require("js-yaml").safeLoad(podfileLockContents);
 

--- a/tests/ios-podfile.test.ts
+++ b/tests/ios-podfile.test.ts
@@ -81,13 +81,16 @@ describe("Podfile should not reference commit hashes checks", () => {
                       - TestDep1 (~> 2.0-beta)
                       - TestDep2(from \`https://github.com/test/pod2.git\`, commit \`5dbb1b2ef4b3b8157569df5878b9ea67e3a9377a\`)
                       - TestDep3 (~> 1.7.2)
+                    - WordPressKit (~> 6.1.0-beta):
+                      - WordPressShared(from \`https://github.com/test/pod2.git\`, commit \`e123bd0a9fef58a5897ed2101044f56a42e614c7\`)
+                    - StandalonePod (~> 1.2.7)
                 `
             )
         );
 
         await iosMacos();
 
-        expect(dm.fail).toHaveBeenCalledWith("Podfile: reference to a commit hash for TestPod,TestDep2");
+        expect(dm.fail).toHaveBeenCalledWith("Podfile: reference to a commit hash for TestPod,TestDep2,WordPressShared");
     })
 
     it("does not fail when finds no commit", async () => {


### PR DESCRIPTION
This PR tracks @AliSoftware's suggestions on top of #109.

GitHub reports the tests failing via its Checks, but when I select the [build](https://buildkite.com/automattic/peril-settings/builds/45), it 404s.

![image](https://user-images.githubusercontent.com/1218433/218614512-a07e9e08-549b-4989-8883-5697e59f1df2.png)

Interestingly, Buildkite can't find a `peril-settings` pipeline:

![image](https://user-images.githubusercontent.com/1218433/218614549-e816dcac-1518-4af5-b7f3-bb2fe9ebcf8e.png)

🤔 

[There's been an incident a couple of hours ago](https://www.buildkitestatus.com/incidents/t7hn25fb7fds), which _might_ have to do with this although it should have been resolved by now. I'll wait a bit and check again.