### PR TITLE
Add `merge_group` event listener to WordPress iOS repo

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -8,6 +8,9 @@
     "rules": {},
     "repos": {
         "wordpress-mobile/WordPress-iOS": {
+            "merge_group": [
+                "Automattic/peril-settings@org/pr/ios-macos.ts"
+            ],
             "pull_request": [
                 "Automattic/peril-settings@org/pr/ios-macos.ts",
                 "Automattic/peril-settings@org/pr/milestone.ts"


### PR DESCRIPTION
This should allow us to run the required Peril check when attempting a merge on `trunk` from the Merge Queue.

I set it up only for WordPress iOS because that's the repo where we are currently experimenting with merge queues. If this proves successful, we shall add it to other repos, too.

Also, I was tempted to extract the `ios-macos.ts` setting in a `"merge_group, pull_request"` entry, but didn't know how Peril would have behaved with the same event declared in multiple entries, so I left it as it was.

See:

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
- https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/