### PR TITLE
Update regex pattern for checking commit hashes in Podfile

### DIFF
--- a/org/pr/ios-macos.ts
+++ b/org/pr/ios-macos.ts
@@ -16,7 +16,7 @@ export default async () => {
 
     // Podfile should not reference commit hashes
     const podfileContents = await danger.github.utils.fileContents("Podfile");
-    const matches = podfileContents.match(/^[^#[]*:commit/gm);
+    const matches = podfileContents.match(/^[^#[]*(commit:|:commit)/gm);
     if (matches !== null) {
         fail("Podfile: reference to a commit hash");
     }

--- a/tests/ios-macos.test.ts
+++ b/tests/ios-macos.test.ts
@@ -94,7 +94,7 @@ describe("Podfile should not reference commit hashes checks", () => {
 
     it("fails when finds a commit hash (mobile gutenberg style)", async () => {
         let podFile : string = "tag_or_commit = options[:tag] || options[:commit]\n";
-        podFile += "gutenberg :commit => '84396ab3e79ff7cde5bf59310e1458336fd9b6b6'\n";
+        podFile += "gutenberg commit: '84396ab3e79ff7cde5bf59310e1458336fd9b6b6'\n";
         dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(podFile));
 
         await iosMacos();


### PR DESCRIPTION
This PR updates the regex pattern that checks that `Podfile` doesn't reference commit hashes. Especially, this change aims to cover the new format used for the Gutenberg pod reference in WP-iOS ([reference](https://github.com/wordpress-mobile/WordPress-iOS/blob/1affdf8309d68eb8fcbc151ce4e979a8c381204d/Podfile#L94)), e.g.:
```
gutenberg tag: 'v1.89.0'
```

**To test:**
1. Run `yarn install`
2. Run `yarn test`
3. Observe that all test pass ✅ 