### PR TITLE
Remove checks from WordPress iOS that now run on Danger

### DIFF
--- a/peril-settings.json
+++ b/peril-settings.json
@@ -12,18 +12,10 @@
                 "Automattic/peril-settings@org/pr/ios-macos.ts"
             ],
             "pull_request": [
-                "Automattic/peril-settings@org/pr/ios-macos.ts",
-                "Automattic/peril-settings@org/pr/milestone.ts"
-            ],
-            "pull_request.opened, pull_request.labeled, pull_request.unlabeled": [
-                "Automattic/peril-settings@org/pr/label.ts"
+                "Automattic/peril-settings@org/pr/ios-macos.ts"
             ],
             "issues.opened, issues.labeled, issues.unlabeled": [
                 "Automattic/peril-settings@org/issue/label.ts"
-            ],
-            "pull_request.opened, pull_request.synchronize, pull_request.labeled, pull_request.unlabeled": [
-                "Automattic/peril-settings@org/pr/ios-diff-size.ts",
-                "Automattic/peril-settings@org/pr/release-notes.ts"
             ],
             "status": [
                 "Automattic/peril-settings@org/pr/installable-build.ts",


### PR DESCRIPTION
The `Dangerfile` and dangermattic version I referred to for these changes was from b2a5d65112d6580c29c8b7f5ab33b00c35a0759d, https://github.com/wordpress-mobile/WordPress-iOS/tree/b2a5d65112d6580c29c8b7f5ab33b00c35a0759d

Notice I didn't remove the rules to run the `ios-macos.ts` checks because I noticed those checks include one for the Core Data model, which I couldn't find replicated either in dangermattic or in the local WordPress iOS setup.