### PR TITLE
Update iOS checks to prevent pods to be referenced by branch, not commit

### DIFF
--- a/org/pr/ios-macos.ts
+++ b/org/pr/ios-macos.ts
@@ -59,20 +59,26 @@ export default async () => {
 //                Otherwise, will be an `object`, with the pod being the single key, and the value being the dependencies
 // @return The new list with any commit-referenced pod found added to the initial `list`
 function parseCommitPods(list: string[], entry: any): string[] {
-    // Example of relevant Podfile.lock portion:
-    //
-    // DEPENDENCIES:
-    //     - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, branch `main`)
-    //     - WordPress-Editor-iOS (~> 1.19.8)
-    //     - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS`, commit `5ab5fd3dc8f50a27181cf14e101abe3599398cad`)
-    //     - WordPressKit (~> 6.1.0-beta):
-    //       - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `e123bd0a9fef58a5897ed2101044f56a42e614c7`)
+    return parsePods(/(.*) \(from .*, commit `.*`/, list, entry);
+}
+
+// Function used as a reducer to parse and accumulate pods from Podfile.lock that match a given RegExp.
+// Uses recursion to parse transitive dependencies of each entry.
+//
+// @param list - The accumulated list of pods matching the condition RegExp so far
+// @param entry - an entry representing a pod listed in the lockfile.
+//                Will be a `string` if the pod has no dependencies.
+//                Otherwise, will be an `object`, with the pod being the single key, and the value being the dependencies
+// @return The new list with any matching pod found added to the initial `list`
+function parsePods(regexp: RegExp, list: string[], entry: any): string[] {
     if (typeof entry === 'string') {
-        const match = entry.match(/(.*) \(from .*, commit `.*`/);
+        const match = entry.match(regexp);
         if (match != null) { list.push(match[1]) };
     } else {
         const key: string = Object.keys(entry)[0];
-        list = [key, ...entry[key]].reduce(parseCommitPods, list);
+        list = [key, ...entry[key]].reduce((accumulator, current) => {
+            return parsePods(regexp, accumulator, current);
+        }, list);
     }
     return list
 }


### PR DESCRIPTION
The same as https://github.com/Automattic/dangermattic/pull/30 but implemented here in Peril just so we don't get conflicting comments while Peril still runs on PRs.

I'm very happy we had unit tests for this, because I think the only way to verify its behavior otherwise is to merge the change and see how it works in production.